### PR TITLE
Update unit-node.sh to support Typscript and other common naming standards

### DIFF
--- a/scripts/test/unit-node.sh
+++ b/scripts/test/unit-node.sh
@@ -65,6 +65,7 @@ if [[ -d "./node_modules/jest" ]]; then
     TEST_REPORTER="jest-sonar-reporter"
     SONAR_FLAGS="$SONAR_FLAGS -Dsonar.testExecutionReportPaths=test-report.xml"
     SONAR_FLAGS="$SONAR_FLAGS -Dsonar.tests=src"
+    #support Typscript and other common naming standards
     SONAR_FLAGS="$SONAR_FLAGS -Dsonar.test.inclusions=**/*.test.tsx,**/*.test.ts,**/*.test.js,**/*.spec.tsx,**/*.spec.ts,**/*.spec.js"
     if [[ "$USE_NPM" == true ]]; then
         echo "Installing $TEST_REPORTER"

--- a/scripts/test/unit-node.sh
+++ b/scripts/test/unit-node.sh
@@ -65,7 +65,7 @@ if [[ -d "./node_modules/jest" ]]; then
     TEST_REPORTER="jest-sonar-reporter"
     SONAR_FLAGS="$SONAR_FLAGS -Dsonar.testExecutionReportPaths=test-report.xml"
     SONAR_FLAGS="$SONAR_FLAGS -Dsonar.tests=src"
-    SONAR_FLAGS="$SONAR_FLAGS -Dsonar.test.inclusions=**/*.spec.js"
+    SONAR_FLAGS="$SONAR_FLAGS -Dsonar.test.inclusions=**/*.test.tsx,**/*.test.ts,**/*.test.js,**/*.spec.tsx,**/*.spec.ts,**/*.spec.js"
     if [[ "$USE_NPM" == true ]]; then
         echo "Installing $TEST_REPORTER"
         COMMAND_ARGS="-- --testResultsProcessor $TEST_REPORTER"


### PR DESCRIPTION
Closes #12 

Asupport Typscript and other common naming standard

#### Changelog

**New**

- Added support for .ts?x and *.test files in SonarQube reporting

**Changed**

- the SonarQube file inclusion flags

**Removed**

- Nada

#### Testing / Reviewing

We need to test w/ an app with Typescript tests
