### PR TITLE
Feat pnpm

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,1 +1,1 @@
-{ "printWidth": 300}
+{ "printWidth": 300 }

--- a/commands/build.js
+++ b/commands/build.js
@@ -229,7 +229,7 @@ module.exports = {
       log.ci("Compile & Package Artifact(s)");
       shell.cd(dir + "/repository");
       await exec(`${shellDir}/build/initialize-dependencies-node.sh "${taskParams["languageVersion"]}" "${taskParams["buildTool"]}" "${taskParams["node-cypress-install-binary"]}"`);
-      await exec(`${shellDir}/build/compile-package-npm.sh ${JSON.stringify(taskParams["artifactoryUrl"])} ${taskParams["artifactoryUser"]} ${taskParams["artifactoryPassword"]}`);
+      await exec(`${shellDir}/build/compile-package-npm.sh "${taskParams["languageVersion"]}" ${JSON.stringify(taskParams["artifactoryUrl"])} ${taskParams["artifactoryUser"]} ${taskParams["artifactoryPassword"]}`);
     } catch (e) {
       log.err("  Error encountered. Code: " + e.code + ", Message:", e.message);
       process.exit(1);
@@ -330,6 +330,7 @@ module.exports = {
       await exec(
         `${shellDir}/build/validate-sync-helm.sh "${taskParams["repoType"]}" "${taskParams["repoUrl"]}" "${taskParams["repoUser"]}" "${taskParams["repoPassword"]}" "${taskParams["gitRepoOwner"]}" "${taskParams["gitRepoName"]}" "${taskParams["gitCommitId"]}" "${taskParams["repoIndexBranch"]}"`
       );
+      qq;
     } catch (e) {
       log.err("  Error encountered. Code: " + e.code + ", Message:", e.message);
       process.exit(1);

--- a/commands/build.js
+++ b/commands/build.js
@@ -192,11 +192,11 @@ module.exports = {
       log.ci("Initializing Dependencies");
       await exec(`${shellDir}/common/initialize.sh`);
       await exec(`${shellDir}/common/initialize-dependencies-node.sh "${taskParams["languageVersion"]}" "${taskParams["buildTool"]}" ${JSON.stringify(taskParams["repoUrl"])} ${taskParams["repoUser"]} "${taskParams["repoPassword"]}"`);
-      await exec(`${shellDir}/build/initialize-dependencies-node.sh "${taskParams["languageVersion"]}" "${taskParams["buildTool"]}" "${taskParams["node-cypress-install-binary"]}"`);
 
       log.ci("Compile & Package Artifact(s)");
       shell.cd(dir + "/repository");
-      await exec(`${shellDir}/build/compile-node.sh "${taskParams["packageScript"]}"`);
+      await exec(`${shellDir}/build/initialize-dependencies-node.sh "${taskParams["languageVersion"]}" "${taskParams["buildTool"]}" "${taskParams["node-cypress-install-binary"]}"`);
+      await exec(`${shellDir}/build/compile-node.sh "${taskParams["languageVersion"]}" "${taskParams["packageScript"]}"`);
     } catch (e) {
       log.err("  Error encountered. Code: " + e.code + ", Message:", e.message);
       process.exit(1);
@@ -225,10 +225,10 @@ module.exports = {
       log.ci("Initializing Dependencies");
       await exec(`${shellDir}/common/initialize.sh`);
       await exec(`${shellDir}/common/initialize-dependencies-node.sh "${taskParams["languageVersion"]}" "${taskParams["buildTool"]}" ${JSON.stringify(taskParams["repoUrl"])} ${taskParams["repoUser"]} "${taskParams["repoPassword"]}"`);
-      await exec(`${shellDir}/build/initialize-dependencies-node.sh "${taskParams["languageVersion"]}" "${taskParams["buildTool"]}" "${taskParams["node-cypress-install-binary"]}"`);
 
       log.ci("Compile & Package Artifact(s)");
       shell.cd(dir + "/repository");
+      await exec(`${shellDir}/build/initialize-dependencies-node.sh "${taskParams["languageVersion"]}" "${taskParams["buildTool"]}" "${taskParams["node-cypress-install-binary"]}"`);
       await exec(`${shellDir}/build/compile-package-npm.sh ${JSON.stringify(taskParams["artifactoryUrl"])} ${taskParams["artifactoryUser"]} ${taskParams["artifactoryPassword"]}`);
     } catch (e) {
       log.err("  Error encountered. Code: " + e.code + ", Message:", e.message);

--- a/commands/build.js
+++ b/commands/build.js
@@ -70,11 +70,21 @@ module.exports = {
       log.ci("Initializing Dependencies");
       await exec(`${shellDir}/common/initialize.sh`);
       // await exec(`${shellDir}/common/initialize-dependencies-java.sh ${taskParams["languageVersion"]}`);
-      await exec(`${shellDir}/common/initialize-dependencies-java-tool.sh ${taskParams["buildTool"]} ${taskParams["buildToolVersion"]}`);
+      await exec(`${shellDir}/common/initialize-dependencies-java-tool.sh \
+      ${taskParams["buildTool"]} \
+      ${taskParams["buildToolVersion"]}`);
 
       log.ci("Compile & Package Artifact(s)");
       shell.cd(dir + "/repository");
-      await exec(`${shellDir}/build/compile-java.sh "${taskParams["languageVersion"]}" ${taskParams["buildTool"]} ${taskParams["buildToolVersion"]} ${version} ${JSON.stringify(taskParams["repoUrl"])} ${taskParams["repoId"]} ${taskParams["repoUser"]} "${taskParams["repoPassword"]}"`);
+      await exec(`${shellDir}/build/compile-java.sh \
+      "${taskParams["languageVersion"]}" \
+      ${taskParams["buildTool"]} \
+      ${taskParams["buildToolVersion"]} \
+      ${version} \
+      ${JSON.stringify(taskParams["repoUrl"])} \
+      ${taskParams["repoId"]} \
+      ${taskParams["repoUser"]} \
+      "${taskParams["repoPassword"]}"`);
     } catch (e) {
       log.err("  Error encountered. Code: " + e.code + ", Message:", e.message);
       process.exit(1);
@@ -108,7 +118,15 @@ module.exports = {
 
       log.ci("Compile & Package Artifact(s)");
       shell.cd(dir + "/repository");
-      await exec(`${shellDir}/build/compile-package-jar.sh "${taskParams["languageVersion"]}" ${taskParams["buildTool"]} ${taskParams["buildToolVersion"]} ${version} ${JSON.stringify(taskParams["repoUrl"])} ${taskParams["repoId"]} ${taskParams["repoUser"]} "${taskParams["repoPassword"]}"`);
+      await exec(`${shellDir}/build/compile-package-jar.sh \
+      "${taskParams["languageVersion"]}" \
+      ${taskParams["buildTool"]} \
+      ${taskParams["buildToolVersion"]} \
+      ${version} \
+      ${JSON.stringify(taskParams["repoUrl"])} \
+      ${taskParams["repoId"]} \
+      ${taskParams["repoUser"]} \
+      "${taskParams["repoPassword"]}"`);
     } catch (e) {
       log.err("  Error encountered. Code: " + e.code + ", Message:", e.message);
       process.exit(1);
@@ -160,9 +178,18 @@ module.exports = {
               .replace(/[^a-zA-Z0-9\-]/g, "")
               .toLowerCase();
       await exec(
-        `${shellDir}/build/package-container.sh "${dockerImageName}" "${version}" "${dockerImagePath}" "${taskParams["buildArgs"]}" "${dockerFile}" ${JSON.stringify(taskParams["globalContainerRegistryHost"])} "${taskParams["globalContainerRegistryPort"]}" "${
-          taskParams["globalContainerRegistryUser"]
-        }" "${taskParams["globalContainerRegistryPassword"]}" ${JSON.stringify(taskParams["containerRegistryHost"])} "${taskParams["containerRegistryPort"]}" "${taskParams["containerRegistryUser"]}" "${taskParams["containerRegistryPassword"]}"`
+        `${shellDir}/build/package-container.sh \
+        "${dockerImageName}" \
+        "${version}" \
+        "${dockerImagePath}" \
+        "${taskParams["buildArgs"]}" \
+        "${dockerFile}" ${JSON.stringify(taskParams["globalContainerRegistryHost"])} \
+        "${taskParams["globalContainerRegistryPort"]}" \
+        "${taskParams["globalContainerRegistryUser"]}" \
+        "${taskParams["globalContainerRegistryPassword"]}" ${JSON.stringify(taskParams["containerRegistryHost"])} \
+        "${taskParams["containerRegistryPort"]}" \
+        "${taskParams["containerRegistryUser"]}" \
+        "${taskParams["containerRegistryPassword"]}"`
       );
     } catch (e) {
       log.err("  Error encountered. Code: " + e.code + ", Message:", e.message);
@@ -191,12 +218,23 @@ module.exports = {
     try {
       log.ci("Initializing Dependencies");
       await exec(`${shellDir}/common/initialize.sh`);
-      await exec(`${shellDir}/common/initialize-dependencies-node.sh "${taskParams["languageVersion"]}" "${taskParams["buildTool"]}" ${JSON.stringify(taskParams["repoUrl"])} ${taskParams["repoUser"]} "${taskParams["repoPassword"]}"`);
+      await exec(`${shellDir}/common/initialize-dependencies-node.sh \
+      "${taskParams["languageVersion"]}" \
+      "${taskParams["buildTool"]}" \
+      ${JSON.stringify(taskParams["repoUrl"])} \
+      ${taskParams["repoUser"]} \
+      "${taskParams["repoPassword"]}"`);
 
       log.ci("Compile & Package Artifact(s)");
       shell.cd(dir + "/repository");
-      await exec(`${shellDir}/build/initialize-dependencies-node.sh "${taskParams["languageVersion"]}" "${taskParams["buildTool"]}" "${taskParams["node-cypress-install-binary"]}"`);
-      await exec(`${shellDir}/build/compile-node.sh "${taskParams["languageVersion"]}" "${taskParams["packageScript"]}"`);
+      await exec(`${shellDir}/build/initialize-dependencies-node.sh \
+      "${taskParams["languageVersion"]}" \
+      "${taskParams["buildTool"]}" \
+      "${taskParams["node-cypress-install-binary"]}"`);
+
+      await exec(`${shellDir}/build/compile-node.sh \
+      "${taskParams["languageVersion"]}" \
+      "${taskParams["packageScript"]}"`);
     } catch (e) {
       log.err("  Error encountered. Code: " + e.code + ", Message:", e.message);
       process.exit(1);
@@ -224,12 +262,23 @@ module.exports = {
     try {
       log.ci("Initializing Dependencies");
       await exec(`${shellDir}/common/initialize.sh`);
-      await exec(`${shellDir}/common/initialize-dependencies-node.sh "${taskParams["languageVersion"]}" "${taskParams["buildTool"]}" ${JSON.stringify(taskParams["repoUrl"])} ${taskParams["repoUser"]} "${taskParams["repoPassword"]}"`);
+      await exec(`${shellDir}/common/initialize-dependencies-node.sh \
+      "${taskParams["languageVersion"]}" \
+      "${taskParams["buildTool"]}" ${JSON.stringify(taskParams["repoUrl"])} ${taskParams["repoUser"]} \
+      "${taskParams["repoPassword"]}"`);
 
       log.ci("Compile & Package Artifact(s)");
       shell.cd(dir + "/repository");
-      await exec(`${shellDir}/build/initialize-dependencies-node.sh "${taskParams["languageVersion"]}" "${taskParams["buildTool"]}" "${taskParams["node-cypress-install-binary"]}"`);
-      await exec(`${shellDir}/build/compile-package-npm.sh "${taskParams["languageVersion"]}" ${JSON.stringify(taskParams["artifactoryUrl"])} ${taskParams["artifactoryUser"]} ${taskParams["artifactoryPassword"]}`);
+      await exec(`${shellDir}/build/initialize-dependencies-node.sh \
+      "${taskParams["languageVersion"]}" \
+      "${taskParams["buildTool"]}" \
+      "${taskParams["node-cypress-install-binary"]}"`);
+
+      await exec(`${shellDir}/build/compile-package-npm.sh \
+      "${taskParams["languageVersion"]}" \
+      ${JSON.stringify(taskParams["artifactoryUrl"])} \
+      ${taskParams["artifactoryUser"]} \
+      ${taskParams["artifactoryPassword"]}`);
     } catch (e) {
       log.err("  Error encountered. Code: " + e.code + ", Message:", e.message);
       process.exit(1);
@@ -260,7 +309,12 @@ module.exports = {
 
       log.ci("Compile & Package Artifact(s)");
       shell.cd(dir + "/repository");
-      await exec(`${shellDir}/build/compile-python.sh "${taskParams["languageVersion"]}" "${JSON.stringify(taskParams["repoUrl"])}" "${taskParams["repoId"]}" "${taskParams["repoUser"]}" "${taskParams["repoPassword"]}"`);
+      await exec(`${shellDir}/build/compile-python.sh \
+      "${taskParams["languageVersion"]}" \
+      "${JSON.stringify(taskParams["repoUrl"])}" \
+      "${taskParams["repoId"]}" \
+      "${taskParams["repoUser"]}" \
+      "${taskParams["repoPassword"]}"`);
     } catch (e) {
       log.err("  Error encountered. Code: " + e.code + ", Message:", e.message);
       process.exit(1);
@@ -293,7 +347,13 @@ module.exports = {
 
       log.ci("Compile & Package Artifact(s)");
       shell.cd(dir + "/repository");
-      await exec(`${shellDir}/build/compile-package-python-wheel.sh "${taskParams["languageVersion"]}" "${version}" "${JSON.stringify(taskParams["repoUrl"])}" "${taskParams["repoId"]}" "${taskParams["repoUser"]}" "${taskParams["repoPassword"]}"`);
+      await exec(`${shellDir}/build/compile-package-python-wheel.sh \
+      "${taskParams["languageVersion"]}" \
+      "${version}" \
+      "${JSON.stringify(taskParams["repoUrl"])}" \
+      "${taskParams["repoId"]}" \
+      "${taskParams["repoUser"]}" \
+      "${taskParams["repoPassword"]}"`);
     } catch (e) {
       log.err("  Error encountered. Code: " + e.code + ", Message:", e.message);
       process.exit(1);
@@ -320,15 +380,50 @@ module.exports = {
     try {
       log.ci("Initializing Dependencies");
       await exec(`${shellDir}/common/initialize.sh`);
-      await exec(`${shellDir}/common/initialize-dependencies-helm.sh "${taskParams["buildToolVersion"]}"`);
+      await exec(`${shellDir}/common/initialize-dependencies-helm.sh \
+      "${taskParams["buildToolVersion"]}"`);
 
       log.ci("Compile & Package Artifact(s)");
       shell.cd(dir + "/repository");
-      // await exec(`${shellDir}/build/package-helm.sh "${taskParams["build.tool"]}" "${taskParams["version.name"]}" "${taskParams["helm.repo.url"]}" "${taskParams["helm.chart.directory"]}" "${taskParams["helm.chart.ignore"]}" "${taskParams["helm.chart.version.increment"]}" "${taskParams["helm.chart.version.tag"]}" "${taskParams["git.ref"]}"`);
-      // await exec(`${shellDir}/build/validate-sync-helm.sh "${taskParams["build.tool"]}" "${taskParams["helm.repo.type"]}" "${taskParams["helm.repo.url"]}" "${taskParams["helm.repo.user"]}" "${taskParams["helm.repo.password"]}" "${taskParams["component/repoOwner"]}" "${taskParams["component/repoName"]}" "${taskParams["git.commit.id"]}" "${taskParams["helm.repo.index.branch"]}"`);
-      await exec(`${shellDir}/build/package-helm.sh "${taskParams["repoUrl"]}" "${taskParams["chartDirectory"]}" "${taskParams["chartIgnore"]}" "${taskParams["chartVersionIncrement"]}" "${taskParams["chartVersionTag"]}" "${taskParams["gitRef"]}"`);
+      // await exec(`${shellDir}/build/package-helm.sh \
+      // "${taskParams["build.tool"]}" \
+      // "${taskParams["version.name"]}" \
+      // "${taskParams["helm.repo.url"]}" \
+      // "${taskParams["helm.chart.directory"]}" \
+      // "${taskParams["helm.chart.ignore"]}" \
+      // "${taskParams["helm.chart.version.increment"]}" \
+      // "${taskParams["helm.chart.version.tag"]}" \
+      // "${taskParams["git.ref"]}"`);
+
+      // await exec(`${shellDir}/build/validate-sync-helm.sh \
+      // "${taskParams["build.tool"]}" \
+      // "${taskParams["helm.repo.type"]}" \
+      // "${taskParams["helm.repo.url"]}" \
+      // "${taskParams["helm.repo.user"]}" \
+      // "${taskParams["helm.repo.password"]}" \
+      // "${taskParams["component/repoOwner"]}" \
+      // "${taskParams["component/repoName"]}" \
+      // "${taskParams["git.commit.id"]}" \
+      // "${taskParams["helm.repo.index.branch"]}"`);
+
+      await exec(`${shellDir}/build/package-helm.sh \
+      "${taskParams["repoUrl"]}" \
+      "${taskParams["chartDirectory"]}" \
+      "${taskParams["chartIgnore"]}" \
+      "${taskParams["chartVersionIncrement"]}" \
+      "${taskParams["chartVersionTag"]}" \
+      "${taskParams["gitRef"]}"`);
+
       await exec(
-        `${shellDir}/build/validate-sync-helm.sh "${taskParams["repoType"]}" "${taskParams["repoUrl"]}" "${taskParams["repoUser"]}" "${taskParams["repoPassword"]}" "${taskParams["gitRepoOwner"]}" "${taskParams["gitRepoName"]}" "${taskParams["gitCommitId"]}" "${taskParams["repoIndexBranch"]}"`
+        `${shellDir}/build/validate-sync-helm.sh \
+        "${taskParams["repoType"]}" \
+        "${taskParams["repoUrl"]}" \
+        "${taskParams["repoUser"]}" \
+        "${taskParams["repoPassword"]}" \
+        "${taskParams["gitRepoOwner"]}" \
+        "${taskParams["gitRepoName"]}" \
+        "${taskParams["gitCommitId"]}" \
+        "${taskParams["repoIndexBranch"]}"`
       );
       qq;
     } catch (e) {

--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -53,7 +53,12 @@ module.exports = {
     let dir = workingDir(taskParams["workingDir"]);
     try {
       log.ci("Initializing Dependencies");
-      await exec(`${shellDir}/deploy/initialize-dependencies-kube.sh "${taskParams["kubeVersion"]}" "${taskParams["kubeNamespace"]}" "${taskParams["kubeHost"]}" "${taskParams["kubeIP"]}" "${taskParams["kubeToken"]}"`);
+      await exec(`${shellDir}/deploy/initialize-dependencies-kube.sh \
+      "${taskParams["kubeVersion"]}" \
+      "${taskParams["kubeNamespace"]}" \
+      "${taskParams["kubeHost"]}" \
+      "${taskParams["kubeIP"]}" \
+      "${taskParams["kubeToken"]}"`);
 
       log.ci("Deploying...");
       var kubeFiles = taskParams["kubeFiles"];
@@ -81,11 +86,25 @@ module.exports = {
     const version = parseVersion(taskParams["version"], taskParams["appendBuildNumber"]);
     try {
       log.ci("Initializing Dependencies");
-      await exec(`${shellDir}/deploy/initialize-dependencies-kube.sh "${taskParams["kubeVersion"]}" "${taskParams["kubeNamespace"]}" "${taskParams["kubeHost"]}" "${taskParams["kubeIP"]}" "${taskParams["kubeToken"]}"`);
+      await exec(`${shellDir}/deploy/initialize-dependencies-kube.sh \
+      "${taskParams["kubeVersion"]}" \
+      "${taskParams["kubeNamespace"]}" \
+      "${taskParams["kubeHost"]}" \
+      "${taskParams["kubeIP"]}" \
+      "${taskParams["kubeToken"]}"`);
+
       await exec(`${shellDir}/common/initialize-dependencies-helm.sh "${taskParams["helmVersion"]}"`);
 
       log.ci("Deploying../");
-      await exec(`${shellDir}/deploy/helm.sh "${taskParams["repoUrl"]}" "${taskParams["helmChart"]}" "${taskParams["helmRelease"]}" "${taskParams["helmImageTag"]}" "${version}" "${taskParams["kubeVersion"]}" "${taskParams["kubeNamespace"]}" "${taskParams["kubeHost"]}"`);
+      await exec(`${shellDir}/deploy/helm.sh \
+      "${taskParams["repoUrl"]}" \
+      "${taskParams["helmChart"]}" \
+      "${taskParams["helmRelease"]}" \
+      "${taskParams["helmImageTag"]}" \
+      "${version}" \
+      "${taskParams["kubeVersion"]}" \
+      "${taskParams["kubeNamespace"]}" \
+      "${taskParams["kubeHost"]}"`);
     } catch (e) {
       log.err("  Error encountered. Code: " + e.code + ", Message:", e.message);
       process.exit(1);
@@ -108,8 +127,13 @@ module.exports = {
     // const version = parseVersion(taskParams["version"], taskParams["appendBuildNumber"]);
     try {
       log.ci("Initializing Dependencies");
-      await exec(`${shellDir}/deploy/initialize-dependencies-kube.sh "${taskParams["kubeVersion"]}" "${taskParams["kubeNamespace"]}" \
-      "${taskParams["kubeHost"]}" "${taskParams["kubeIP"]}" "${taskParams["kubeToken"]}"`);
+
+      await exec(`${shellDir}/deploy/initialize-dependencies-kube.sh \
+      "${taskParams["kubeVersion"]}" \
+      "${taskParams["kubeNamespace"]}" \
+      "${taskParams["kubeHost"]}" \
+      "${taskParams["kubeIP"]}" \
+      "${taskParams["kubeToken"]}"`);
       await exec(`${shellDir}/common/initialize-dependencies-helm.sh "${taskParams["helmVersion"]}"`);
 
       log.ci("Deploying...");
@@ -162,11 +186,20 @@ module.exports = {
               .toString()
               .replace(/[^a-zA-Z0-9\-]/g, "")
               .toLowerCase();
-      await exec(
-        `${shellDir}/deploy/containerregistry.sh "${dockerImageName}" "${taskParams["version"]}" "${dockerImagePath}" ${JSON.stringify(taskParams["containerRegistryHost"])} "${taskParams["containerRegistryPort"]}" "${taskParams["containerRegistryUser"]}" "${
-          taskParams["containerRegistryPassword"]
-        }" "${taskParams["containerRegistryPath"]}" ${JSON.stringify(taskParams["globalContainerRegistryHost"])} "${taskParams["globalContainerRegistryPort"]}" "${taskParams["globalContainerRegistryUser"]}" "${taskParams["globalContainerRegistryPassword"]}" "${taskParams["cisoCodesignEnable"]}"`
-      );
+      await exec(`${shellDir}/deploy/containerregistry.sh \
+      "${dockerImageName}" \
+      "${taskParams["version"]}" \
+      "${dockerImagePath}" \
+      ${JSON.stringify(taskParams["containerRegistryHost"])} \
+      "${taskParams["containerRegistryPort"]}" \
+      "${taskParams["containerRegistryUser"]}" \
+      "${taskParams["containerRegistryPassword"]}" \
+      "${taskParams["containerRegistryPath"]}" \
+      ${JSON.stringify(taskParams["globalContainerRegistryHost"])} \
+      "${taskParams["globalContainerRegistryPort"]}" \
+      "${taskParams["globalContainerRegistryUser"]}" \
+      "${taskParams["globalContainerRegistryPassword"]}" \
+      "${taskParams["cisoCodesignEnable"]}"`);
     } catch (e) {
       log.err("  Error encountered. Code: " + e.code + ", Message:", e.message);
       process.exit(1);
@@ -192,11 +225,18 @@ module.exports = {
     shell.cd(dir + "/repository");
     await exec("ls -ltr");
     try {
-      await exec(
-        `${shellDir}/deploy/containerregistry-tar.sh "${taskParams["imageName"]}" "${taskParams["version"]}" "${taskParams["imagePath"]}" ${JSON.stringify(taskParams["globalContainerRegistryHost"])} "${taskParams["globalContainerRegistryPort"]}" "${taskParams["globalContainerRegistryUser"]}" "${
-          taskParams["globalContainerRegistryPassword"]
-        }" ${JSON.stringify(taskParams["containerRegistryHost"])} "${taskParams["containerRegistryPort"]}" "${taskParams["containerRegistryUser"]}" "${taskParams["containerRegistryPassword"]}"`
-      );
+      await exec(`${shellDir}/deploy/containerregistry-tar.sh \
+      "${taskParams["imageName"]}" \
+      "${taskParams["version"]}" \
+      "${taskParams["imagePath"]}" \
+      ${JSON.stringify(taskParams["globalContainerRegistryHost"])} \
+      "${taskParams["globalContainerRegistryPort"]}" \
+      "${taskParams["globalContainerRegistryUser"]}" \
+      "${taskParams["globalContainerRegistryPassword"]}" \
+      ${JSON.stringify(taskParams["containerRegistryHost"])} \
+      "${taskParams["containerRegistryPort"]}" \
+      "${taskParams["containerRegistryUser"]}" \
+      "${taskParams["containerRegistryPassword"]}"`);
     } catch (e) {
       log.err("  Error encountered. Code: " + e.code + ", Message:", e.message);
       process.exit(1);

--- a/commands/git.js
+++ b/commands/git.js
@@ -2,10 +2,10 @@ const { log, utils, CICDError } = require("@boomerang-io/worker-core");
 const shell = require("shelljs");
 
 function exec(command) {
-  return new Promise(function (resolve, reject) {
+  return new Promise(function(resolve, reject) {
     log.debug("Command directory:", shell.pwd().toString());
     log.debug("Command to execute:", command);
-    shell.exec(command, { verbose: true }, function (code, stdout, stderr) {
+    shell.exec(command, { verbose: true }, function(code, stdout, stderr) {
       if (code) {
         reject(new CICDError(code, stderr));
       }

--- a/commands/git.js
+++ b/commands/git.js
@@ -42,7 +42,13 @@ module.exports = {
 
     try {
       log.ci("Retrieving Source Code");
-      await exec(`${shellDir}/common/git-clone.sh "${repoDir}" "${taskParams["privateKey"]}" ${JSON.stringify(taskParams["repoSshUrl"])} ${JSON.stringify(taskParams["repoUrl"])} ${taskParams["commitId"]} ${taskParams["lfsEnabled"]}`);
+      await exec(`${shellDir}/common/git-clone.sh \
+      "${repoDir}" \
+      "${taskParams["privateKey"]}" \
+      ${JSON.stringify(taskParams["repoSshUrl"])} \
+      ${JSON.stringify(taskParams["repoUrl"])} \
+      ${taskParams["commitId"]} \
+      ${taskParams["lfsEnabled"]}`);
 
       log.sys("Finished Git Clone task...");
     } catch (e) {

--- a/commands/test.js
+++ b/commands/test.js
@@ -13,10 +13,10 @@ const TestType = {
 Object.freeze(TestType);
 
 function exec(command) {
-  return new Promise(function (resolve, reject) {
+  return new Promise(function(resolve, reject) {
     log.debug("Command directory:", shell.pwd().toString());
     log.debug("Command to execute:", command);
-    shell.exec(command, config, function (code, stdout, stderr) {
+    shell.exec(command, config, function(code, stdout, stderr) {
       if (code) {
         reject(new CICDError(code, stderr));
       }
@@ -78,7 +78,7 @@ module.exports = {
     const version = parseVersion(taskParams["version"], taskParams["appendBuildNumber"]);
 
     try {
-      log.debug("Initializing Dependencies");
+      log.ci("Initializing Dependencies");
       await exec(`${shellDir}/common/initialize.sh`);
       await exec(`${shellDir}/common/initialize-dependencies-java.sh ${taskParams["languageVersion"]}`);
       await exec(`${shellDir}/common/initialize-dependencies-java-tool.sh ${taskParams["buildTool"]} ${taskParams["buildToolVersion"]}`);
@@ -120,17 +120,29 @@ module.exports = {
       if (testTypes.includes(TestType.Security)) {
         log.debug("Commencing security tests");
         shell.cd(workdir);
-        await exec(`${shellDir}/test/security-java.sh ${taskParams["systemComponentName"]} ${version} ${JSON.stringify(taskParams["asocRepoUrl"])} ${taskParams["asocRepoUser"]} ${taskParams["asocRepoPassword"]} ${taskParams["asocAppId"]} ${taskParams["asocLoginKeyId"]} ${taskParams["asocLoginSecret"]} ${taskParams["asocClientCli"]} ${taskParams["asocJavaRuntime"]} ${shellDir} ${testdir}`);
+        await exec(
+          `${shellDir}/test/security-java.sh ${taskParams["systemComponentName"]} ${version} ${JSON.stringify(taskParams["asocRepoUrl"])} ${taskParams["asocRepoUser"]} ${taskParams["asocRepoPassword"]} ${taskParams["asocAppId"]} ${taskParams["asocLoginKeyId"]} ${taskParams["asocLoginSecret"]} ${
+            taskParams["asocClientCli"]
+          } ${taskParams["asocJavaRuntime"]} ${shellDir} ${testdir}`
+        );
       }
       if (testTypes.includes(TestType.SeleniumNative)) {
         log.debug("Commencing automated Selenium native tests");
         shell.cd(workdir);
-        await exec(`${shellDir}/test/selenium-native.sh ${taskParams["systemComponentName"]} ${version} ${taskParams["saucelabsApiKey"]} ${taskParams["saucelabsApiUser"]} ${JSON.stringify(taskParams["saucelabsApiUrl"])} ${taskParams["browserName"]} ${taskParams["browserVersion"]} ${taskParams["platformType"]} ${taskParams["platformVersion"]} ${taskParams["webTestsFolder"]} ${taskParams["gitUser"]} ${taskParams["gitPassword"]} ${shellDir} ${testdir}`);
+        await exec(
+          `${shellDir}/test/selenium-native.sh ${taskParams["systemComponentName"]} ${version} ${taskParams["saucelabsApiKey"]} ${taskParams["saucelabsApiUser"]} ${JSON.stringify(taskParams["saucelabsApiUrl"])} ${taskParams["browserName"]} ${taskParams["browserVersion"]} ${
+            taskParams["platformType"]
+          } ${taskParams["platformVersion"]} ${taskParams["webTestsFolder"]} ${taskParams["gitUser"]} ${taskParams["gitPassword"]} ${shellDir} ${testdir}`
+        );
       }
       if (testTypes.includes(TestType.SeleniumCustom)) {
         log.debug("Commencing automated Selenium custom tests");
         shell.cd(workdir);
-        await exec(`${shellDir}/test/selenium-custom.sh "${taskParams["teamName"]}" ${taskParams["systemComponentName"]} ${version} ${taskParams["seleniumApplicationPropertiesFile"]} ${taskParams["seleniumApplicationPropertiesKey"]} ${taskParams["saucelabsApiUrlWithCredentials"]} ${taskParams["seleniumReportFolder"]} ${JSON.stringify(taskParams["artifactoryUrl"])} ${taskParams["artifactoryUser"]} ${taskParams["artifactoryPassword"]} ${shellDir} ${testdir}`);
+        await exec(
+          `${shellDir}/test/selenium-custom.sh "${taskParams["teamName"]}" ${taskParams["systemComponentName"]} ${version} ${taskParams["seleniumApplicationPropertiesFile"]} ${taskParams["seleniumApplicationPropertiesKey"]} ${taskParams["saucelabsApiUrlWithCredentials"]} ${
+            taskParams["seleniumReportFolder"]
+          } ${JSON.stringify(taskParams["artifactoryUrl"])} ${taskParams["artifactoryUser"]} ${taskParams["artifactoryPassword"]} ${shellDir} ${testdir}`
+        );
       }
     } catch (e) {
       log.err("  Error encountered. Code: " + e.code + ", Message:", e.message);
@@ -210,7 +222,11 @@ module.exports = {
       if (testTypes.includes(TestType.Security)) {
         log.debug("Commencing security tests");
         shell.cd(workdir);
-        await exec(`${shellDir}/test/security-java.sh ${taskParams["systemComponentName"]} ${version} ${JSON.stringify(taskParams["asocRepoUrl"])} ${taskParams["asocRepoUser"]} ${taskParams["asocRepoPassword"]} ${taskParams["asocAppId"]} ${taskParams["asocLoginKeyId"]} ${taskParams["asocLoginSecret"]} ${taskParams["asocClientCli"]} ${taskParams["asocJavaRuntime"]} ${shellDir} ${testdir}`);
+        await exec(
+          `${shellDir}/test/security-java.sh ${taskParams["systemComponentName"]} ${version} ${JSON.stringify(taskParams["asocRepoUrl"])} ${taskParams["asocRepoUser"]} ${taskParams["asocRepoPassword"]} ${taskParams["asocAppId"]} ${taskParams["asocLoginKeyId"]} ${taskParams["asocLoginSecret"]} ${
+            taskParams["asocClientCli"]
+          } ${taskParams["asocJavaRuntime"]} ${shellDir} ${testdir}`
+        );
       }
       if (testTypes.includes(TestType.SeleniumNative)) {
         log.debug("Native Selenium testing type not supported for Jar");
@@ -227,7 +243,7 @@ module.exports = {
     }
   },
   async nodejs() {
-    log.debug("Started Boomerang CICD NodeJS Test Activity");
+    log.debug("Started Boomerang CICD Node.js Test Activity");
 
     //Destructure and get properties ready.
     const taskParams = utils.resolveInputParameters();
@@ -257,38 +273,112 @@ module.exports = {
     try {
       log.ci("Initializing Dependencies");
       await exec(`${shellDir}/common/initialize.sh`);
-      await exec(`${shellDir}/common/initialize-dependencies-node.sh ${taskParams["buildTool"]} ${JSON.stringify(taskParams["artifactoryUrl"])} ${taskParams["artifactoryUser"]} ${taskParams["artifactoryPassword"]}`);
-      await exec(`${shellDir}/test/initialize-dependencies-node.sh ${taskParams["buildTool"]} ${taskParams["nodeCypressInstallBinary"]}`);
+      await exec(`${shellDir}/common/initialize-dependencies-node.sh ${taskParams["languageVersion"]} ${taskParams["buildTool"]} ${JSON.stringify(taskParams["artifactoryUrl"])} ${taskParams["artifactoryUser"]} ${taskParams["artifactoryPassword"]}`);
+
+      log.ci("Test Artifacts");
+      shell.cd(workdir);
+      await exec(`${shellDir}/test/initialize-dependencies-node.sh ${taskParams["languageVersion"]} ${taskParams["buildTool"]} ${taskParams["nodeCypressInstallBinary"]}`);
 
       if (testTypes.includes(TestType.Static)) {
         log.debug("Commencing static tests");
-        shell.cd(workdir);
-        await exec(`${shellDir}/test/static-node.sh ${taskParams["buildTool"]} ${version} ${taskParams["sonarUrl"]} ${taskParams["sonarApiKey"]} ${taskParams["systemComponentId"]} ${taskParams["systemComponentName"]}`);
+        await exec(`${shellDir}/test/static-node.sh ${taskParams["languageVersion"]} ${taskParams["buildTool"]} ${version} ${taskParams["sonarUrl"]} ${taskParams["sonarApiKey"]} ${taskParams["systemComponentId"]} ${taskParams["systemComponentName"]}`);
       }
       if (testTypes.includes(TestType.Unit)) {
         log.debug("Commencing unit tests");
-        shell.cd(workdir);
-        await exec(`${shellDir}/test/unit-node.sh ${taskParams["buildTool"]} ${version} ${taskParams["sonarUrl"]} ${taskParams["sonarApiKey"]} ${taskParams["systemComponentId"]} ${taskParams["systemComponentName"]}`);
+        await exec(`${shellDir}/test/unit-node.sh ${taskParams["languageVersion"]} ${taskParams["buildTool"]} ${version} ${taskParams["sonarUrl"]} ${taskParams["sonarApiKey"]} ${taskParams["systemComponentId"]} ${taskParams["systemComponentName"]}`);
       }
       if (testTypes.includes(TestType.Security)) {
         log.debug("Commencing security tests");
-        shell.cd(workdir);
-        await exec(`${shellDir}/test/security-node.sh ${taskParams["systemComponentName"]} ${version} ${JSON.stringify(taskParams["asocRepoUrl"])} ${taskParams["asocRepoUser"]} ${taskParams["asocRepoPassword"]} ${taskParams["asocAppId"]} ${taskParams["asocLoginKeyId"]} ${taskParams["asocLoginSecret"]} ${taskParams["asocClientCli"]} ${taskParams["asocJavaRuntime"]} ${shellDir} ${testdir}`);
+        await exec(
+          `${shellDir}/test/security-node.sh ${taskParams["systemComponentName"]} ${version} ${JSON.stringify(taskParams["asocRepoUrl"])} ${taskParams["asocRepoUser"]} ${taskParams["asocRepoPassword"]} ${taskParams["asocAppId"]} ${taskParams["asocLoginKeyId"]} ${taskParams["asocLoginSecret"]} ${
+            taskParams["asocClientCli"]
+          } ${taskParams["asocJavaRuntime"]} ${shellDir} ${testdir}`
+        );
       }
       if (testTypes.includes(TestType.SeleniumNative)) {
         log.debug("Commencing automated Selenium native tests");
-        shell.cd(workdir);
-        await exec(`${shellDir}/test/selenium-native.sh ${taskParams["systemComponentName"]} ${version} ${taskParams["saucelabsApiKey"]} ${taskParams["saucelabsApiUser"]} ${JSON.stringify(taskParams["saucelabsApiUrl"])} ${taskParams["browserName"]} ${taskParams["browserVersion"]} ${taskParams["platformType"]} ${taskParams["platformVersion"]} ${taskParams["webTestsFolder"]} ${taskParams["gitUser"]} ${taskParams["gitPassword"]} ${shellDir} ${testdir}`);
+        await exec(
+          `${shellDir}/test/selenium-native.sh ${taskParams["systemComponentName"]} ${version} ${taskParams["saucelabsApiKey"]} ${taskParams["saucelabsApiUser"]} ${JSON.stringify(taskParams["saucelabsApiUrl"])} ${taskParams["browserName"]} ${taskParams["browserVersion"]} ${
+            taskParams["platformType"]
+          } ${taskParams["platformVersion"]} ${taskParams["webTestsFolder"]} ${taskParams["gitUser"]} ${taskParams["gitPassword"]} ${shellDir} ${testdir}`
+        );
       }
       if (testTypes.includes(TestType.SeleniumCustom)) {
-        log.debug("Custom Selenium testing type not supported for NodeJS");
+        log.debug("Custom Selenium testing type not supported for Node.js");
       }
     } catch (e) {
       log.err("  Error encountered. Code: " + e.code + ", Message:", e.message);
       process.exit(1);
     } finally {
       await exec(shellDir + "/common/footer.sh");
-      log.debug("Finished Boomerang CICD NodeJS test activity");
+      log.debug("Finished Boomerang CICD Node.js test activity");
+    }
+  },
+  async npm() {
+    log.debug("Started Boomerang CICD npm Package Test Activity");
+
+    //Destructure and get properties ready.
+    const taskParams = utils.resolveInputParameters();
+    // const { path, script } = taskParams;
+    const shellDir = "/cli/scripts";
+    config = {
+      verbose: true
+    };
+
+    // let dir = "/workspace/" + taskParams["workflow-activity-id"];
+    let dir = workingDir(taskParams["workingDir"]);
+
+    let workdir = dir + "/repository";
+    log.debug("Working Directory: ", workdir);
+
+    let testdir = "/test";
+    shell.mkdir("-p", testdir);
+    log.debug("Test Directory: ", testdir);
+
+    // log.debug("Copy source code from shared drive to container");
+    // shell.mkdir("-p", workdir);
+    // shell.cp("-R", dir + "/repository/*", testdir);
+
+    const testTypes = typeof taskParams["testType"] === "string" ? taskParams["testType"].split(",") : [];
+    const version = parseVersion(taskParams["version"], taskParams["appendBuildNumber"]);
+
+    try {
+      log.ci("Initializing Dependencies");
+      await exec(`${shellDir}/common/initialize.sh`);
+      await exec(`${shellDir}/common/initialize-dependencies-node.sh ${taskParams["languageVersion"]} ${taskParams["buildTool"]} ${JSON.stringify(taskParams["artifactoryUrl"])} ${taskParams["artifactoryUser"]} ${taskParams["artifactoryPassword"]}`);
+
+      log.ci("Test Artifacts");
+      shell.cd(workdir);
+      await exec(`${shellDir}/test/initialize-dependencies-node.sh ${taskParams["languageVersion"]} ${taskParams["buildTool"]} ${taskParams["nodeCypressInstallBinary"]}`);
+
+      if (testTypes.includes(TestType.Static)) {
+        log.debug("Commencing static tests");
+        await exec(`${shellDir}/test/static-node.sh ${taskParams["languageVersion"]} ${taskParams["buildTool"]} ${version} ${taskParams["sonarUrl"]} ${taskParams["sonarApiKey"]} ${taskParams["systemComponentId"]} ${taskParams["systemComponentName"]}`);
+      }
+      if (testTypes.includes(TestType.Unit)) {
+        log.debug("Commencing unit tests");
+        await exec(`${shellDir}/test/unit-node.sh ${taskParams["languageVersion"]} ${taskParams["buildTool"]} ${version} ${taskParams["sonarUrl"]} ${taskParams["sonarApiKey"]} ${taskParams["systemComponentId"]} ${taskParams["systemComponentName"]}`);
+      }
+      if (testTypes.includes(TestType.Security)) {
+        log.debug("Commencing security tests");
+        await exec(
+          `${shellDir}/test/security-node.sh ${taskParams["systemComponentName"]} ${version} ${JSON.stringify(taskParams["asocRepoUrl"])} ${taskParams["asocRepoUser"]} ${taskParams["asocRepoPassword"]} ${taskParams["asocAppId"]} ${taskParams["asocLoginKeyId"]} ${taskParams["asocLoginSecret"]} ${
+            taskParams["asocClientCli"]
+          } ${taskParams["asocJavaRuntime"]} ${shellDir} ${testdir}`
+        );
+      }
+      if (testTypes.includes(TestType.SeleniumCustom)) {
+        log.debug("Custom Selenium testing type not supported for npm packages");
+      }
+      if (testTypes.includes(TestType.SeleniumCustom)) {
+        log.debug("Custom Selenium testing type not supported for npm packages");
+      }
+    } catch (e) {
+      log.err("  Error encountered. Code: " + e.code + ", Message:", e.message);
+      process.exit(1);
+    } finally {
+      await exec(shellDir + "/common/footer.sh");
+      log.debug("Finished Boomerang CICD Node.js test activity");
     }
   },
   async python() {
@@ -339,7 +429,11 @@ module.exports = {
       if (testTypes.includes(TestType.SeleniumNative)) {
         log.debug("Commencing automated Selenium native tests");
         shell.cd(workdir);
-        await exec(`${shellDir}/test/selenium-native.sh ${taskParams["systemComponentName"]} ${version} ${taskParams["saucelabsApiKey"]} ${taskParams["saucelabsApiUser"]} ${JSON.stringify(taskParams["saucelabsApiUrl"])} ${taskParams["browserName"]} ${taskParams["browserVersion"]} ${taskParams["platformType"]} ${taskParams["platformVersion"]} ${taskParams["webTestsFolder"]} ${taskParams["gitUser"]} ${taskParams["gitPassword"]} ${shellDir} ${testdir}`);
+        await exec(
+          `${shellDir}/test/selenium-native.sh ${taskParams["systemComponentName"]} ${version} ${taskParams["saucelabsApiKey"]} ${taskParams["saucelabsApiUser"]} ${JSON.stringify(taskParams["saucelabsApiUrl"])} ${taskParams["browserName"]} ${taskParams["browserVersion"]} ${
+            taskParams["platformType"]
+          } ${taskParams["platformVersion"]} ${taskParams["webTestsFolder"]} ${taskParams["gitUser"]} ${taskParams["gitPassword"]} ${shellDir} ${testdir}`
+        );
       }
       if (testTypes.includes(TestType.SeleniumCustom)) {
         log.debug("Custom Selenium testing type not supported for Python");

--- a/commands/test.js
+++ b/commands/test.js
@@ -109,40 +109,76 @@ module.exports = {
       if (testTypes.includes(TestType.Static)) {
         log.debug("Commencing static tests");
         shell.cd(workdir);
-        await exec(`${shellDir}/test/static-java.sh ${taskParams["buildTool"]} ${version} ${taskParams["sonarUrl"]} ${taskParams["sonarApiKey"]} ${taskParams["systemComponentId"]} ${taskParams["systemComponentName"]} ${taskParams["sonarExclusions"]}`);
+        await exec(`${shellDir}/test/static-java.sh \
+        ${taskParams["buildTool"]} ${version} \
+        ${taskParams["sonarUrl"]} \
+        ${taskParams["sonarApiKey"]} \
+        ${taskParams["systemComponentId"]} \
+        ${taskParams["systemComponentName"]} \
+        ${taskParams["sonarExclusions"]}`);
       }
       if (testTypes.includes(TestType.Unit)) {
         log.debug("Commencing unit tests");
         await exec(`${shellDir}/test/initialize-dependencies-unit-java.sh`);
         shell.cd(workdir);
-        await exec(`${shellDir}/test/unit-java.sh ${taskParams["buildTool"]} ${version} ${taskParams["sonarUrl"]} ${taskParams["sonarApiKey"]} ${taskParams["systemComponentId"]} ${taskParams["systemComponentName"]}`);
+        await exec(`${shellDir}/test/unit-java.sh \
+        ${taskParams["buildTool"]} ${version} \
+        ${taskParams["sonarUrl"]} \
+        ${taskParams["sonarApiKey"]} \
+        ${taskParams["systemComponentId"]} \
+        ${taskParams["systemComponentName"]}`);
       }
       if (testTypes.includes(TestType.Security)) {
         log.debug("Commencing security tests");
         shell.cd(workdir);
         await exec(
-          `${shellDir}/test/security-java.sh ${taskParams["systemComponentName"]} ${version} ${JSON.stringify(taskParams["asocRepoUrl"])} ${taskParams["asocRepoUser"]} ${taskParams["asocRepoPassword"]} ${taskParams["asocAppId"]} ${taskParams["asocLoginKeyId"]} ${taskParams["asocLoginSecret"]} ${
-            taskParams["asocClientCli"]
-          } ${taskParams["asocJavaRuntime"]} ${shellDir} ${testdir}`
+          `${shellDir}/test/security-java.sh \
+          ${taskParams["systemComponentName"]} \
+          ${version} \
+          ${JSON.stringify(taskParams["asocRepoUrl"])} \
+          ${taskParams["asocRepoUser"]} \
+          ${taskParams["asocRepoPassword"]} \
+          ${taskParams["asocAppId"]} \
+          ${taskParams["asocLoginKeyId"]} \
+          ${taskParams["asocLoginSecret"]} \
+          ${taskParams["asocClientCli"]} \
+          ${taskParams["asocJavaRuntime"]} \
+          ${shellDir} \
+          ${testdir}`
         );
       }
       if (testTypes.includes(TestType.SeleniumNative)) {
         log.debug("Commencing automated Selenium native tests");
         shell.cd(workdir);
-        await exec(
-          `${shellDir}/test/selenium-native.sh ${taskParams["systemComponentName"]} ${version} ${taskParams["saucelabsApiKey"]} ${taskParams["saucelabsApiUser"]} ${JSON.stringify(taskParams["saucelabsApiUrl"])} ${taskParams["browserName"]} ${taskParams["browserVersion"]} ${
-            taskParams["platformType"]
-          } ${taskParams["platformVersion"]} ${taskParams["webTestsFolder"]} ${taskParams["gitUser"]} ${taskParams["gitPassword"]} ${shellDir} ${testdir}`
-        );
+        await exec(`${shellDir}/test/selenium-native.sh \
+        ${taskParams["systemComponentName"]} ${version} \
+        ${taskParams["saucelabsApiKey"]} \
+        ${taskParams["saucelabsApiUser"]} ${JSON.stringify(taskParams["saucelabsApiUrl"])} \
+        ${taskParams["browserName"]} \
+        ${taskParams["browserVersion"]} \
+        ${taskParams["platformType"]} \
+        ${taskParams["platformVersion"]} \
+        ${taskParams["webTestsFolder"]} \
+        ${taskParams["gitUser"]} \
+        ${taskParams["gitPassword"]} \
+        ${shellDir} \
+        ${testdir}`);
       }
       if (testTypes.includes(TestType.SeleniumCustom)) {
         log.debug("Commencing automated Selenium custom tests");
         shell.cd(workdir);
-        await exec(
-          `${shellDir}/test/selenium-custom.sh "${taskParams["teamName"]}" ${taskParams["systemComponentName"]} ${version} ${taskParams["seleniumApplicationPropertiesFile"]} ${taskParams["seleniumApplicationPropertiesKey"]} ${taskParams["saucelabsApiUrlWithCredentials"]} ${
-            taskParams["seleniumReportFolder"]
-          } ${JSON.stringify(taskParams["artifactoryUrl"])} ${taskParams["artifactoryUser"]} ${taskParams["artifactoryPassword"]} ${shellDir} ${testdir}`
-        );
+        await exec(`${shellDir}/test/selenium-custom.sh "\
+        ${taskParams["teamName"]}" \
+        ${taskParams["systemComponentName"]} ${version} \
+        ${taskParams["seleniumApplicationPropertiesFile"]} \
+        ${taskParams["seleniumApplicationPropertiesKey"]} \
+        ${taskParams["saucelabsApiUrlWithCredentials"]} \
+        ${taskParams["seleniumReportFolder"]} \
+        ${JSON.stringify(taskParams["artifactoryUrl"])} \
+        ${taskParams["artifactoryUser"]} \
+        ${taskParams["artifactoryPassword"]} \
+        ${shellDir} \
+        ${testdir}`);
       }
     } catch (e) {
       log.err("  Error encountered. Code: " + e.code + ", Message:", e.message);
@@ -184,7 +220,9 @@ module.exports = {
       log.ci("Initializing Dependencies");
       await exec(`${shellDir}/common/initialize.sh`);
       await exec(`${shellDir}/common/initialize-dependencies-java.sh ${taskParams["languageVersion"]}`);
-      await exec(`${shellDir}/common/initialize-dependencies-java-tool.sh ${taskParams["buildTool"]} ${taskParams["buildToolVersion"]}`);
+      await exec(`${shellDir}/common/initialize-dependencies-java-tool.sh \
+      ${taskParams["buildTool"]} \
+      ${taskParams["buildToolVersion"]}`);
 
       if (!common.checkFileContainsStringWithProps(workdir + "/pom.xml", "<plugins>", undefined, false)) {
         log.debug("No Maven plugins found, adding...");
@@ -211,22 +249,41 @@ module.exports = {
       if (testTypes.includes(TestType.Static)) {
         log.debug("Commencing static tests");
         shell.cd(workdir);
-        await exec(`${shellDir}/test/static-java.sh ${taskParams["buildTool"]} ${version} ${taskParams["sonarUrl"]} ${taskParams["sonarApiKey"]} ${taskParams["systemComponentId"]} ${taskParams["systemComponentName"]} ${taskParams["sonarExclusions"]}`);
+        await exec(`${shellDir}/test/static-java.sh \
+        ${taskParams["buildTool"]} ${version} \
+        ${taskParams["sonarUrl"]} \
+        ${taskParams["sonarApiKey"]} \
+        ${taskParams["systemComponentId"]} \
+        ${taskParams["systemComponentName"]} \
+        ${taskParams["sonarExclusions"]}`);
       }
       if (testTypes.includes(TestType.Unit)) {
         log.debug("Commencing unit tests");
         await exec(`${shellDir}/test/initialize-dependencies-unit-java.sh`);
         shell.cd(workdir);
-        await exec(`${shellDir}/test/unit-java.sh ${taskParams["buildTool"]} ${version} ${taskParams["sonarUrl"]} ${taskParams["sonarApiKey"]} ${taskParams["systemComponentId"]} ${taskParams["systemComponentName"]}`);
+        await exec(`${shellDir}/test/unit-java.sh \
+        ${taskParams["buildTool"]} ${version} \
+        ${taskParams["sonarUrl"]} \
+        ${taskParams["sonarApiKey"]} \
+        ${taskParams["systemComponentId"]} \
+        ${taskParams["systemComponentName"]}`);
       }
       if (testTypes.includes(TestType.Security)) {
         log.debug("Commencing security tests");
         shell.cd(workdir);
-        await exec(
-          `${shellDir}/test/security-java.sh ${taskParams["systemComponentName"]} ${version} ${JSON.stringify(taskParams["asocRepoUrl"])} ${taskParams["asocRepoUser"]} ${taskParams["asocRepoPassword"]} ${taskParams["asocAppId"]} ${taskParams["asocLoginKeyId"]} ${taskParams["asocLoginSecret"]} ${
-            taskParams["asocClientCli"]
-          } ${taskParams["asocJavaRuntime"]} ${shellDir} ${testdir}`
-        );
+        await exec(`${shellDir}/test/security-java.sh \
+          ${taskParams["systemComponentName"]} \
+          ${version} \
+          ${JSON.stringify(taskParams["asocRepoUrl"])} \
+          ${taskParams["asocRepoUser"]} \
+          ${taskParams["asocRepoPassword"]} \
+          ${taskParams["asocAppId"]} \
+          ${taskParams["asocLoginKeyId"]} \
+          ${taskParams["asocLoginSecret"]} \
+          ${taskParams["asocClientCli"]} \
+          ${taskParams["asocJavaRuntime"]} \
+          ${shellDir} \
+          ${testdir}`);
       }
       if (testTypes.includes(TestType.SeleniumNative)) {
         log.debug("Native Selenium testing type not supported for Jar");
@@ -273,34 +330,73 @@ module.exports = {
     try {
       log.ci("Initializing Dependencies");
       await exec(`${shellDir}/common/initialize.sh`);
-      await exec(`${shellDir}/common/initialize-dependencies-node.sh ${taskParams["languageVersion"]} ${taskParams["buildTool"]} ${JSON.stringify(taskParams["artifactoryUrl"])} ${taskParams["artifactoryUser"]} ${taskParams["artifactoryPassword"]}`);
+      await exec(`${shellDir}/common/initialize-dependencies-node.sh \
+      ${taskParams["languageVersion"]} \
+      ${taskParams["buildTool"]} \
+      ${JSON.stringify(taskParams["artifactoryUrl"])} \
+      ${taskParams["artifactoryUser"]} \
+      ${taskParams["artifactoryPassword"]}`);
 
       log.ci("Test Artifacts");
       shell.cd(workdir);
-      await exec(`${shellDir}/test/initialize-dependencies-node.sh ${taskParams["languageVersion"]} ${taskParams["buildTool"]} ${taskParams["nodeCypressInstallBinary"]}`);
+      await exec(`${shellDir}/test/initialize-dependencies-node.sh \
+      ${taskParams["languageVersion"]} \
+      ${taskParams["buildTool"]} \
+      ${taskParams["nodeCypressInstallBinary"]}`);
 
       if (testTypes.includes(TestType.Static)) {
         log.debug("Commencing static tests");
-        await exec(`${shellDir}/test/static-node.sh ${taskParams["languageVersion"]} ${taskParams["buildTool"]} ${version} ${taskParams["sonarUrl"]} ${taskParams["sonarApiKey"]} ${taskParams["systemComponentId"]} ${taskParams["systemComponentName"]}`);
+        await exec(`${shellDir}/test/static-node.sh \
+        ${taskParams["languageVersion"]} \
+        ${taskParams["buildTool"]} ${version} \
+        ${taskParams["sonarUrl"]} \
+        ${taskParams["sonarApiKey"]} \
+        ${taskParams["systemComponentId"]} \
+        ${taskParams["systemComponentName"]}`);
       }
       if (testTypes.includes(TestType.Unit)) {
         log.debug("Commencing unit tests");
-        await exec(`${shellDir}/test/unit-node.sh ${taskParams["languageVersion"]} ${taskParams["buildTool"]} ${version} ${taskParams["sonarUrl"]} ${taskParams["sonarApiKey"]} ${taskParams["systemComponentId"]} ${taskParams["systemComponentName"]}`);
+        await exec(`${shellDir}/test/unit-node.sh \
+        ${taskParams["languageVersion"]} \
+        ${taskParams["buildTool"]} ${version} \
+        ${taskParams["sonarUrl"]} \
+        ${taskParams["sonarApiKey"]} \
+        ${taskParams["systemComponentId"]} \
+        ${taskParams["systemComponentName"]}`);
       }
       if (testTypes.includes(TestType.Security)) {
         log.debug("Commencing security tests");
         await exec(
-          `${shellDir}/test/security-node.sh ${taskParams["systemComponentName"]} ${version} ${JSON.stringify(taskParams["asocRepoUrl"])} ${taskParams["asocRepoUser"]} ${taskParams["asocRepoPassword"]} ${taskParams["asocAppId"]} ${taskParams["asocLoginKeyId"]} ${taskParams["asocLoginSecret"]} ${
-            taskParams["asocClientCli"]
-          } ${taskParams["asocJavaRuntime"]} ${shellDir} ${testdir}`
+          `${shellDir}/test/security-node.sh \
+          ${taskParams["systemComponentName"]} \
+          ${version} \
+          ${JSON.stringify(taskParams["asocRepoUrl"])} \
+          ${taskParams["asocRepoUser"]} \
+          ${taskParams["asocRepoPassword"]} \
+          ${taskParams["asocAppId"]} \
+          ${taskParams["asocLoginKeyId"]} \
+          ${taskParams["asocLoginSecret"]} \
+          ${taskParams["asocClientCli"]} \
+          ${taskParams["asocJavaRuntime"]} \
+          ${shellDir} \
+          ${testdir}`
         );
       }
       if (testTypes.includes(TestType.SeleniumNative)) {
         log.debug("Commencing automated Selenium native tests");
         await exec(
-          `${shellDir}/test/selenium-native.sh ${taskParams["systemComponentName"]} ${version} ${taskParams["saucelabsApiKey"]} ${taskParams["saucelabsApiUser"]} ${JSON.stringify(taskParams["saucelabsApiUrl"])} ${taskParams["browserName"]} ${taskParams["browserVersion"]} ${
-            taskParams["platformType"]
-          } ${taskParams["platformVersion"]} ${taskParams["webTestsFolder"]} ${taskParams["gitUser"]} ${taskParams["gitPassword"]} ${shellDir} ${testdir}`
+          `${shellDir}/test/selenium-native.sh \
+          ${taskParams["systemComponentName"]} ${version} \
+          ${taskParams["saucelabsApiKey"]} \
+          ${taskParams["saucelabsApiUser"]} ${JSON.stringify(taskParams["saucelabsApiUrl"])} \
+          ${taskParams["browserName"]} \
+          ${taskParams["browserVersion"]} ${taskParams["platformType"]} \
+          ${taskParams["platformVersion"]} \
+          ${taskParams["webTestsFolder"]} \
+          ${taskParams["gitUser"]} \
+          ${taskParams["gitPassword"]} \
+          ${shellDir} \
+          ${testdir}`
         );
       }
       if (testTypes.includes(TestType.SeleniumCustom)) {
@@ -345,26 +441,58 @@ module.exports = {
     try {
       log.ci("Initializing Dependencies");
       await exec(`${shellDir}/common/initialize.sh`);
-      await exec(`${shellDir}/common/initialize-dependencies-node.sh ${taskParams["languageVersion"]} ${taskParams["buildTool"]} ${JSON.stringify(taskParams["artifactoryUrl"])} ${taskParams["artifactoryUser"]} ${taskParams["artifactoryPassword"]}`);
+      await exec(`${shellDir}/common/initialize-dependencies-node.sh \
+      ${taskParams["languageVersion"]} \
+      ${taskParams["buildTool"]} \
+      ${JSON.stringify(taskParams["artifactoryUrl"])} \
+      ${taskParams["artifactoryUser"]} \
+      ${taskParams["artifactoryPassword"]}`);
 
       log.ci("Test Artifacts");
       shell.cd(workdir);
-      await exec(`${shellDir}/test/initialize-dependencies-node.sh ${taskParams["languageVersion"]} ${taskParams["buildTool"]} ${taskParams["nodeCypressInstallBinary"]}`);
+      await exec(`${shellDir}/test/initialize-dependencies-node.sh \
+      ${taskParams["languageVersion"]} \
+      ${taskParams["buildTool"]} \
+      ${taskParams["nodeCypressInstallBinary"]}`);
 
       if (testTypes.includes(TestType.Static)) {
         log.debug("Commencing static tests");
-        await exec(`${shellDir}/test/static-node.sh ${taskParams["languageVersion"]} ${taskParams["buildTool"]} ${version} ${taskParams["sonarUrl"]} ${taskParams["sonarApiKey"]} ${taskParams["systemComponentId"]} ${taskParams["systemComponentName"]}`);
+        await exec(`${shellDir}/test/static-node.sh \
+        ${taskParams["languageVersion"]} \
+        ${taskParams["buildTool"]} \
+        ${version} \
+        ${taskParams["sonarUrl"]} \
+        ${taskParams["sonarApiKey"]} \
+        ${taskParams["systemComponentId"]} \
+        ${taskParams["systemComponentName"]}`);
       }
       if (testTypes.includes(TestType.Unit)) {
         log.debug("Commencing unit tests");
-        await exec(`${shellDir}/test/unit-node.sh ${taskParams["languageVersion"]} ${taskParams["buildTool"]} ${version} ${taskParams["sonarUrl"]} ${taskParams["sonarApiKey"]} ${taskParams["systemComponentId"]} ${taskParams["systemComponentName"]}`);
+        await exec(`${shellDir}/test/unit-node.sh \
+        ${taskParams["languageVersion"]} \
+        ${taskParams["buildTool"]} \
+        ${version} \
+        ${taskParams["sonarUrl"]} \
+        ${taskParams["sonarApiKey"]} \
+        ${taskParams["systemComponentId"]} \
+        ${taskParams["systemComponentName"]}`);
       }
       if (testTypes.includes(TestType.Security)) {
         log.debug("Commencing security tests");
         await exec(
-          `${shellDir}/test/security-node.sh ${taskParams["systemComponentName"]} ${version} ${JSON.stringify(taskParams["asocRepoUrl"])} ${taskParams["asocRepoUser"]} ${taskParams["asocRepoPassword"]} ${taskParams["asocAppId"]} ${taskParams["asocLoginKeyId"]} ${taskParams["asocLoginSecret"]} ${
-            taskParams["asocClientCli"]
-          } ${taskParams["asocJavaRuntime"]} ${shellDir} ${testdir}`
+          `${shellDir}/test/security-node.sh \
+          ${taskParams["systemComponentName"]} \
+          ${version} \
+          ${JSON.stringify(taskParams["asocRepoUrl"])} \
+          ${taskParams["asocRepoUser"]} \
+          ${taskParams["asocRepoPassword"]} \
+          ${taskParams["asocAppId"]} \
+          ${taskParams["asocLoginKeyId"]} \
+          ${taskParams["asocLoginSecret"]} \
+          ${taskParams["asocClientCli"]} \
+          ${taskParams["asocJavaRuntime"]} \
+          ${shellDir} \
+          ${testdir}`
         );
       }
       if (testTypes.includes(TestType.SeleniumCustom)) {
@@ -412,13 +540,24 @@ module.exports = {
     try {
       log.ci("Initializing Dependencies");
       await exec(`${shellDir}/common/initialize.sh`);
-      await exec(`${shellDir}/common/initialize-dependencies-python.sh ${taskParams["languageVersion"]}`);
+      await exec(`${shellDir}/common/initialize-dependencies-python.sh \
+      ${taskParams["languageVersion"]}`);
 
       if (testTypes.includes(TestType.Static)) {
         log.debug("Commencing static tests");
-        await exec(`${shellDir}/test/initialize-dependencies-static-python.sh ${taskParams["languageVersion"]} ${JSON.stringify(taskParams["pypiRegistryHost"])} ${taskParams["pypiRepoId"]} ${taskParams["pypiRepoUser"]} ${taskParams["pypiRepoPassword"]}`);
+        await exec(`${shellDir}/test/initialize-dependencies-static-python.sh \
+        ${taskParams["languageVersion"]} ${JSON.stringify(taskParams["pypiRegistryHost"])} \
+        ${taskParams["pypiRepoId"]} \
+        ${taskParams["pypiRepoUser"]} \
+        ${taskParams["pypiRepoPassword"]}`);
+
         shell.cd(workdir);
-        await exec(`${shellDir}/test/static-python.sh ${taskParams["buildTool"]} ${version} ${taskParams["sonarUrl"]} ${taskParams["sonarApiKey"]} ${taskParams["systemComponentId"]} ${taskParams["systemComponentName"]}`);
+        await exec(`${shellDir}/test/static-python.sh \
+        ${taskParams["buildTool"]} ${version} \
+        ${taskParams["sonarUrl"]} \
+        ${taskParams["sonarApiKey"]} \
+        ${taskParams["systemComponentId"]} \
+        ${taskParams["systemComponentName"]}`);
       }
       if (testTypes.includes(TestType.Unit)) {
         log.debug("Unit tests not implemented for Python");
@@ -430,9 +569,20 @@ module.exports = {
         log.debug("Commencing automated Selenium native tests");
         shell.cd(workdir);
         await exec(
-          `${shellDir}/test/selenium-native.sh ${taskParams["systemComponentName"]} ${version} ${taskParams["saucelabsApiKey"]} ${taskParams["saucelabsApiUser"]} ${JSON.stringify(taskParams["saucelabsApiUrl"])} ${taskParams["browserName"]} ${taskParams["browserVersion"]} ${
-            taskParams["platformType"]
-          } ${taskParams["platformVersion"]} ${taskParams["webTestsFolder"]} ${taskParams["gitUser"]} ${taskParams["gitPassword"]} ${shellDir} ${testdir}`
+          `${shellDir}/test/selenium-native.sh \
+          ${taskParams["systemComponentName"]} ${version} \
+          ${taskParams["saucelabsApiKey"]} \
+          ${taskParams["saucelabsApiUser"]} \
+          ${JSON.stringify(taskParams["saucelabsApiUrl"])} \
+          ${taskParams["browserName"]} \
+          ${taskParams["browserVersion"]} \
+          ${taskParams["platformType"]} \
+          ${taskParams["platformVersion"]} \
+          ${taskParams["webTestsFolder"]} \
+          ${taskParams["gitUser"]} \
+          ${taskParams["gitPassword"]} \
+          ${shellDir} \
+          ${testdir}`
         );
       }
       if (testTypes.includes(TestType.SeleniumCustom)) {
@@ -477,12 +627,16 @@ module.exports = {
     try {
       log.ci("Initializing Dependencies");
       await exec(`${shellDir}/common/initialize.sh`);
-      await exec(`${shellDir}/common/initialize-dependencies-helm.sh "${taskParams["buildToolVersion"]}"`);
+      await exec(`${shellDir}/common/initialize-dependencies-helm.sh ${taskParams["buildToolVersion"]}"`);
 
       if (testTypes.includes(TestType.Static)) {
         log.debug("Linting Helm Chart(s)");
         shell.cd(workdir);
-        await exec(`${shellDir}/test/lint-helm.sh ${taskParams["buildTool"]} ${taskParams["helmRepoUrl"]} ${taskParams["helmChartDirectory"]} ${taskParams["helmChartIgnore"]}`);
+        await exec(`${shellDir}/test/lint-helm.sh \
+        ${taskParams["buildTool"]} \
+        ${taskParams["helmRepoUrl"]} \
+        ${taskParams["helmChartDirectory"]} \
+        ${taskParams["helmChartIgnore"]}`);
       }
       if (testTypes.includes(TestType.Unit)) {
         log.debug("Unit tests not implemented for Helm");

--- a/commands/test.js
+++ b/commands/test.js
@@ -344,9 +344,9 @@ module.exports = {
       ${taskParams["buildTool"]} \
       ${taskParams["nodeCypressInstallBinary"]}`);
 
-      if (testTypes.includes(TestType.Static)) {
-        log.debug("Commencing static tests");
-        await exec(`${shellDir}/test/static-node.sh \
+      if (testTypes.includes(TestType.Unit)) {
+        log.debug("Commencing unit tests");
+        await exec(`${shellDir}/test/unit-node.sh \
         ${taskParams["languageVersion"]} \
         ${taskParams["buildTool"]} ${version} \
         ${taskParams["sonarUrl"]} \
@@ -354,9 +354,9 @@ module.exports = {
         ${taskParams["systemComponentId"]} \
         ${taskParams["systemComponentName"]}`);
       }
-      if (testTypes.includes(TestType.Unit)) {
-        log.debug("Commencing unit tests");
-        await exec(`${shellDir}/test/unit-node.sh \
+      if (testTypes.includes(TestType.Static)) {
+        log.debug("Commencing static tests");
+        await exec(`${shellDir}/test/static-node.sh \
         ${taskParams["languageVersion"]} \
         ${taskParams["buildTool"]} ${version} \
         ${taskParams["sonarUrl"]} \
@@ -386,11 +386,14 @@ module.exports = {
         log.debug("Commencing automated Selenium native tests");
         await exec(
           `${shellDir}/test/selenium-native.sh \
-          ${taskParams["systemComponentName"]} ${version} \
+          ${taskParams["systemComponentName"]} \
+          ${version} \
           ${taskParams["saucelabsApiKey"]} \
-          ${taskParams["saucelabsApiUser"]} ${JSON.stringify(taskParams["saucelabsApiUrl"])} \
+          ${taskParams["saucelabsApiUser"]} \
+          ${JSON.stringify(taskParams["saucelabsApiUrl"])} \
           ${taskParams["browserName"]} \
-          ${taskParams["browserVersion"]} ${taskParams["platformType"]} \
+          ${taskParams["browserVersion"]} \
+          ${taskParams["platformType"]} \
           ${taskParams["platformVersion"]} \
           ${taskParams["webTestsFolder"]} \
           ${taskParams["gitUser"]} \
@@ -403,7 +406,7 @@ module.exports = {
         log.debug("Custom Selenium testing type not supported for Node.js");
       }
     } catch (e) {
-      log.err("  Error encountered. Code: " + e.code + ", Message:", e.message);
+      log.err("Error encountered. Code: " + e.code + ", Message:", e.message);
       process.exit(1);
     } finally {
       await exec(shellDir + "/common/footer.sh");
@@ -495,8 +498,8 @@ module.exports = {
           ${testdir}`
         );
       }
-      if (testTypes.includes(TestType.SeleniumCustom)) {
-        log.debug("Custom Selenium testing type not supported for npm packages");
+      if (testTypes.includes(TestType.SeleniumNative)) {
+        log.debug("Native Selenium testing type not supported for npm packages");
       }
       if (testTypes.includes(TestType.SeleniumCustom)) {
         log.debug("Custom Selenium testing type not supported for npm packages");
@@ -570,7 +573,8 @@ module.exports = {
         shell.cd(workdir);
         await exec(
           `${shellDir}/test/selenium-native.sh \
-          ${taskParams["systemComponentName"]} ${version} \
+          ${taskParams["systemComponentName"]} \
+          ${version} \
           ${taskParams["saucelabsApiKey"]} \
           ${taskParams["saucelabsApiUser"]} \
           ${JSON.stringify(taskParams["saucelabsApiUrl"])} \

--- a/scripts/build/compile-node.sh
+++ b/scripts/build/compile-node.sh
@@ -29,7 +29,7 @@ if [ "$SCRIPT" != "undefined" ]; then
         exit 89
     fi
 else
-    # exit 97
-    echo "npm script ($BUILD_SCRIPT) not defined in package.json. Skipping..."
+    # Allow Node.js components to not have a build step
+    echo "npm script ($BUILD_SCRIPT) not defined in the package.json file. Skipping..."
 fi
 

--- a/scripts/build/compile-node.sh
+++ b/scripts/build/compile-node.sh
@@ -5,7 +5,7 @@
 LANGUAGE_VERSION=$1
 BUILD_SCRIPT=$2
 
-# Check if using ubuntu or alpine base image
+# Install configured version of Node.js via nvm if present
 if [ "$LANGUAGE_VERSION" != "undefined" ]; then
     echo "Running with nvm..."
     unset npm_config_prefix

--- a/scripts/build/compile-node.sh
+++ b/scripts/build/compile-node.sh
@@ -2,7 +2,16 @@
 
 # ( printf '\n'; printf '%.0s-' {1..30}; printf ' Build Artifact '; printf '%.0s-' {1..30}; printf '\n\n' )
 
-BUILD_SCRIPT=$1
+LANGUAGE_VERSION=$1
+BUILD_SCRIPT=$2
+
+# Check if using ubuntu or alpine base image
+if [ "$LANGUAGE_VERSION" != "undefined" ]; then
+    echo "Running with nvm..."
+    unset npm_config_prefix
+    source ~/.nvm/nvm.sh
+    nvm use $LANGUAGE_VERSION
+fi
 
 if [ -z "$BUILD_SCRIPT" ]; then
     echo "Build script not specified, defaulting to 'build'..."

--- a/scripts/build/compile-package-npm.sh
+++ b/scripts/build/compile-package-npm.sh
@@ -7,7 +7,7 @@ ART_URL=$2
 ART_USER=$3
 ART_PASSWORD=$4
 
-# Check if using ubuntu or alpine base image
+# Install configured version of Node.js via nvm if present
 if [ "$LANGUAGE_VERSION" != "undefined" ]; then
     echo "Running with nvm..."
     unset npm_config_prefix

--- a/scripts/build/compile-package-npm.sh
+++ b/scripts/build/compile-package-npm.sh
@@ -2,9 +2,18 @@
 
 # ( printf '\n'; printf '%.0s-' {1..30}; printf ' Build Artifact '; printf '%.0s-' {1..30}; printf '\n\n' )
 
-ART_URL=$1
-ART_USER=$2
-ART_PASSWORD=$3
+LANGUAGE_VERSION=$1
+ART_URL=$2
+ART_USER=$3
+ART_PASSWORD=$4
+
+# Check if using ubuntu or alpine base image
+if [ "$LANGUAGE_VERSION" != "undefined" ]; then
+    echo "Running with nvm..."
+    unset npm_config_prefix
+    source ~/.nvm/nvm.sh
+    nvm use $LANGUAGE_VERSION
+fi
 
 DEBUG_OPTS=
 if [ "$DEBUG" == "true" ]; then

--- a/scripts/build/compile-package-npm.sh
+++ b/scripts/build/compile-package-npm.sh
@@ -7,6 +7,15 @@ ART_URL=$2
 ART_USER=$3
 ART_PASSWORD=$4
 
+# Get the scope of the package from the name field
+SCOPE=$(node -pe "require('./package.json').name" | cut -d/ -f1);
+
+if [[ $SCOPE != @* ]]; then
+    echo "Package name must include a scope e.g. '@scope/my-package'"
+    echo "The scope should be unique to your organization/team"
+    exit 95
+fi
+
 # Install configured version of Node.js via nvm if present
 if [ "$LANGUAGE_VERSION" != "undefined" ]; then
     echo "Running with nvm..."
@@ -19,14 +28,6 @@ DEBUG_OPTS=
 if [ "$DEBUG" == "true" ]; then
     echo "Enabling debug logging..."
     DEBUG_OPTS+="--verbose"
-fi
-
-# Get the scope of the package from the name field
-SCOPE=$(node -pe "require('./package.json').name" | cut -d/ -f1);
-
-if [[ $SCOPE != @* ]]; then
-    echo "Package name must include a scope e.g. '@project/my-package'"
-    exit 97
 fi
 
 curl -k -v -u $ART_USER:$ART_PASSWORD $ART_URL/api/npm/boomeranglib-npm/auth/"${SCOPE:1}" -o .npmrc

--- a/scripts/build/initialize-dependencies-node.sh
+++ b/scripts/build/initialize-dependencies-node.sh
@@ -31,7 +31,7 @@ if [ "$DEBUG" == "true" ]; then
     echo "CYPRESS_INSTALL_BINARY=$CYPRESS_INSTALL_BINARY"
 fi
 
-# Check if using ubuntu or alpine base image
+# Install configured version of Node.js via nvm if present
 if [ "$LANGUAGE_VERSION" != "undefined" ]; then
     echo "Running with nvm..."
     unset npm_config_prefix

--- a/scripts/build/initialize-dependencies-node.sh
+++ b/scripts/build/initialize-dependencies-node.sh
@@ -31,7 +31,7 @@ if [ "$DEBUG" == "true" ]; then
     echo "CYPRESS_INSTALL_BINARY=$CYPRESS_INSTALL_BINARY"
 fi
 
-NVM_OPTS=
+# Check if using ubuntu or alpine base image
 if [ "$LANGUAGE_VERSION" != "undefined" ]; then
     echo "Running with nvm..."
     unset npm_config_prefix

--- a/scripts/common/initialize-dependencies-node.sh
+++ b/scripts/common/initialize-dependencies-node.sh
@@ -19,7 +19,7 @@ fi
 
 echo "Using build tool $BUILD_TOOL"
 
-# Check if using ubuntu or alpine base image
+# Install configured version of Node.js via nvm if present
 if [ "$LANGUAGE_VERSION" != "undefined" ]; then
 
     # Install specified version of Node.js

--- a/scripts/common/initialize-dependencies-node.sh
+++ b/scripts/common/initialize-dependencies-node.sh
@@ -19,7 +19,9 @@ fi
 
 echo "Using build tool $BUILD_TOOL"
 
+# Check if using ubuntu or alpine base image
 if [ "$LANGUAGE_VERSION" != "undefined" ]; then
+
     # Install specified version of Node.js
     echo "Using NVM with Node version: $LANGUAGE_VERSION"
     unset npm_config_prefix

--- a/scripts/test/initialize-dependencies-node.sh
+++ b/scripts/test/initialize-dependencies-node.sh
@@ -2,8 +2,9 @@
 
 # ( printf '\n'; printf '%.0s-' {1..30}; printf ' Build Artifact '; printf '%.0s-' {1..30}; printf '\n\n' )
 
-BUILD_TOOL=$1
-CYPRESS_INSTALL_BINARY=$2
+LANGUAGE_VERSION=$1
+BUILD_TOOL=$2
+CYPRESS_INSTALL_BINARY=$3
 
 [[ "$BUILD_TOOL" == "npm" ]] && USE_NPM=true || USE_NPM=false
 [[ "$BUILD_TOOL" == "yarn" ]] && USE_YARN=true || USE_YARN=false
@@ -15,6 +16,13 @@ if [ "$USE_NPM" == false ] && [ "$USE_YARN" == false ] && [ "$USE_PNPM" == false
 fi
 
 echo "Using build tool $BUILD_TOOL"
+
+if [ "$LANGUAGE_VERSION" != "undefined" ]; then
+    echo "Running with nvm..."
+    unset npm_config_prefix
+    source ~/.nvm/nvm.sh
+    nvm use $LANGUAGE_VERSION
+fi
 
 DEBUG_OPTS=
 if [ "$DEBUG" == "true" ]; then

--- a/scripts/test/static-node.sh
+++ b/scripts/test/static-node.sh
@@ -18,7 +18,7 @@ if [ "$LANGUAGE_VERSION" != "undefined" ]; then
     # Dependency for sonarscanner
     export ENV DEBIAN_FRONTEND noninteractive
     apt-get -y update
-    apt-get --no-install-recommends -y install openjdk-8-jdk
+    apt-get --no-install-recommends -y install openjdk-8-jdk unzip
 
     # Set Node.js version
     echo "Running with nvm..."
@@ -42,65 +42,13 @@ fi
 # Set JS heap space
 export NODE_OPTIONS="--max-old-space-size=8192"
 
-# if [ "$USE_NPM" == true ]; then
-#     # Install typescript
-#     npm install -D typescript
-#     npm link typescript
-
-#     # Install eslint
-#     npm install -g eslint
-#     npm link eslint
-
-#     # Install prettier
-#     npm install -g prettier
-#     npm link prettier
-
-#     # Install clean
-#     npm install -g clean
-#     npm link clean
-
-# elif [ "$USE_YARN" == true ]; then
-#     # Install typescript
-#     yarn add -D typescript
-#     yarn link typescript
-
-#     # Install eslint
-#     yarn global add eslint
-#     yarn link eslint
-
-#     # Install prettier
-#     yarn global add prettier
-#     yarn link prettier
-
-#     # Install clean
-#     yarn global add clean
-#     yarn link clean
-    
-# elif [ "$USE_PNPM" == true ]; then
-#     # Install typescript
-#     pnpm add -D typescript
-#     pnpm link typescript
-
-#     # Install eslint
-#     pnpm add -g eslint
-#     pnpm link eslint
-
-#     # Install prettier
-#     pnpm add -g prettier
-#     pnpm link prettier
-
-#     # Install clean
-#     pnpm add -g clean
-#     pnpm link clean
-# fi
-
 # Check SonarQube
 curl --noproxy $NO_PROXY -I --insecure $SONAR_URL/about
 curl --noproxy $NO_PROXY --insecure -X POST -u $SONAR_APIKEY: "$( echo "$SONAR_URL/api/projects/create?&project=$COMPONENT_ID&name="$COMPONENT_NAME"" | sed 's/ /%20/g' )"
 curl --noproxy $NO_PROXY --insecure -X POST -u $SONAR_APIKEY: "$SONAR_URL/api/qualitygates/select?projectKey=$COMPONENT_ID&gateId=$SONAR_GATEID"
 
 # Install sonar-scanner
-curl --insecure -o /opt/sonarscanner.zip -L https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.0.0.1744.zip
+curl --insecure -o /opt/sonarscanner.zip -L https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.7.0.2747.zip
 unzip -o /opt/sonarscanner.zip -d /opt
 SONAR_FOLDER=`ls /opt | grep sonar-scanner`
 SONAR_HOME=/opt/$SONAR_FOLDER
@@ -109,24 +57,15 @@ if [ "$DEBUG" == "true" ]; then
 else
     SONAR_FLAGS=
 fi
+
+# Run linting script
+
 SCRIPT=$(node -pe "require('./package.json').scripts.lint");
-echo "SCRIPT=$SCRIPT"
-if [ "$SCRIPT" != "undefined" ]; then
+if [[ "$SCRIPT" != "undefined" ]]; then
     npm run lint
     SONAR_FLAGS="$SONAR_FLAGS -Dsonar.eslint.reportPaths=lint-report.json"
-fi
-
-ls -al lint-report.json
-echo "SONAR_FLAGS=$SONAR_FLAGS"
-
-
-if [[ "$USE_NPM" == true ]]; then
-    # npm clean-install
-    npm test
-elif [[ "$USE_YARN" == true ]]; then
-    yarn test
-elif [[ "$USE_PNPM" == true ]]; then
-    pnpm test
+    ls -al lint-report.json
+    echo "SONAR_FLAGS=$SONAR_FLAGS"
 fi
 
 SRC_FOLDER=

--- a/scripts/test/static-node.sh
+++ b/scripts/test/static-node.sh
@@ -11,7 +11,9 @@ SONAR_GATEID=2
 COMPONENT_ID=$6
 COMPONENT_NAME=$7
 
-# Check if using ubuntu or alpine base image
+# Install configured version of Node.js via nvm if present
+# Also install JDK correctly depending on what the underlying Linux image is
+# Ubuntu or Alpine
 if [ "$LANGUAGE_VERSION" != "undefined" ]; then
     # Dependency for sonarscanner
     export ENV DEBIAN_FRONTEND noninteractive

--- a/scripts/test/static-node.sh
+++ b/scripts/test/static-node.sh
@@ -2,43 +2,95 @@
 
 #( printf '\n'; printf '%.0s-' {1..30}; printf ' Static Code Analysis '; printf '%.0s-' {1..30}; printf '\n\n' )
 
-BUILD_TOOL=$1
-VERSION_NAME=$2
-SONAR_URL=$3
-SONAR_APIKEY=$4
+LANGUAGE_VERSION=$1
+BUILD_TOOL=$2
+VERSION_NAME=$3
+SONAR_URL=$4
+SONAR_APIKEY=$5
 SONAR_GATEID=2
-COMPONENT_ID=$5
-COMPONENT_NAME=$6
+COMPONENT_ID=$6
+COMPONENT_NAME=$7
+
+# Check if using ubuntu or alpine base image
+if [ "$LANGUAGE_VERSION" != "undefined" ]; then
+    # Dependency for sonarscanner
+    export ENV DEBIAN_FRONTEND noninteractive
+    apt-get -y update
+    apt-get --no-install-recommends -y install openjdk-8-jdk
+
+    # Set Node.js version
+    echo "Running with nvm..."
+    unset npm_config_prefix
+    source ~/.nvm/nvm.sh
+    nvm use $LANGUAGE_VERSION
+else
+    # Dependency for sonarscanner
+    apk add openjdk8
+fi
 
 [[ "$BUILD_TOOL" == "npm" ]] && USE_NPM=true || USE_NPM=false
 [[ "$BUILD_TOOL" == "yarn" ]] && USE_YARN=true || USE_YARN=false
 [[ "$BUILD_TOOL" == "pnpm" ]] && USE_PNPM=true || USE_PNPM=false
 
-if [[ "$USE_NPM" == false ]] && [[ "$USE_YARN" == false ]] && [[ "$USE_PNPM" == false ]]; then
-    exit 99
+if [ "$USE_NPM" == false ] && [ "$USE_YARN" == false ] && [ "$USE_PNPM" == false ]; then
+    echo "build tool not specified, defaulting to 'npm'..."
+    BUILD_TOOL="npm"
 fi
-
-# Dependency for sonarscanner
-apk add openjdk8
 
 # Set JS heap space
 export NODE_OPTIONS="--max-old-space-size=8192"
 
-# Install typescript
-npm install -D typescript
-npm link typescript
+# if [ "$USE_NPM" == true ]; then
+#     # Install typescript
+#     npm install -D typescript
+#     npm link typescript
 
-# Install eslint
-npm install -g eslint
-npm link eslint
+#     # Install eslint
+#     npm install -g eslint
+#     npm link eslint
 
-# Install prettier
-npm install -g prettier
-npm link prettier
+#     # Install prettier
+#     npm install -g prettier
+#     npm link prettier
 
-# Install clean
-npm install -g clean
-npm link clean
+#     # Install clean
+#     npm install -g clean
+#     npm link clean
+
+# elif [ "$USE_YARN" == true ]; then
+#     # Install typescript
+#     yarn add -D typescript
+#     yarn link typescript
+
+#     # Install eslint
+#     yarn global add eslint
+#     yarn link eslint
+
+#     # Install prettier
+#     yarn global add prettier
+#     yarn link prettier
+
+#     # Install clean
+#     yarn global add clean
+#     yarn link clean
+    
+# elif [ "$USE_PNPM" == true ]; then
+#     # Install typescript
+#     pnpm add -D typescript
+#     pnpm link typescript
+
+#     # Install eslint
+#     pnpm add -g eslint
+#     pnpm link eslint
+
+#     # Install prettier
+#     pnpm add -g prettier
+#     pnpm link prettier
+
+#     # Install clean
+#     pnpm add -g clean
+#     pnpm link clean
+# fi
 
 # Check SonarQube
 curl --noproxy $NO_PROXY -I --insecure $SONAR_URL/about
@@ -65,6 +117,7 @@ fi
 ls -al lint-report.json
 echo "SONAR_FLAGS=$SONAR_FLAGS"
 
+
 if [[ "$USE_NPM" == true ]]; then
     # npm clean-install
     npm test
@@ -86,7 +139,7 @@ else
     SRC_FOLDER=.
 fi
 
-# Set NodeJS bin path
+# Set Node.js bin path
 NODE_PATH=$(which node)
 echo "NODE_PATH=$NODE_PATH"
 

--- a/scripts/test/unit-node.sh
+++ b/scripts/test/unit-node.sh
@@ -11,12 +11,20 @@ SONAR_GATEID=2
 COMPONENT_ID=$6
 COMPONENT_NAME=$7
 
+# Fail fast if testing script is not present
+SCRIPT=$(node -pe "require('./package.json').scripts.test");
+if [[ "$SCRIPT" == "undefined" ]]; then
+    echo "'test' script not defined in the package.json file"
+    exit 95
+fi
+
 # Check if using ubuntu or alpine base
+# and install the correct dependencies
 if [ "$LANGUAGE_VERSION" != "undefined" ]; then
     # Dependency for sonarscanner
     export ENV DEBIAN_FRONTEND noninteractive
     apt-get -y update
-    apt-get --no-install-recommends -y install openjdk-8-jdk
+    apt-get --no-install-recommends -y install openjdk-8-jdk unzip
 
     # Set Node.js version
     echo "Running with nvm..."
@@ -32,13 +40,6 @@ fi
 [[ "$BUILD_TOOL" == "yarn" ]] && USE_YARN=true || USE_YARN=false
 [[ "$BUILD_TOOL" == "pnpm" ]] && USE_PNPM=true || USE_PNPM=false
 
-# Fail fast if testing script is not present
-SCRIPT=$(node -pe "require('./package.json').scripts.test");
-if [[ "$SCRIPT" == "undefined" ]]; then
-    echo "Test script not defined"
-    exit 95
-fi
-
 if [[ "$USE_NPM" == false ]] && [[ "$USE_YARN" == false ]] && [[ "$USE_PNPM" == false ]]; then
     echo "Build tool not specified, defaulting to 'npm'..."
     BUILD_TOOL="npm"
@@ -49,65 +50,13 @@ echo "Using build tool $BUILD_TOOL"
 # Set JS heap space
 export NODE_OPTIONS="--max-old-space-size=8192"
 
-# if [ "$USE_NPM" == true ]; then
-#     # Install typescript
-#     npm install -D typescript
-#     npm link typescript
-
-#     # Install eslint
-#     npm install -g eslint
-#     npm link eslint
-
-#     # Install prettier
-#     npm install -g prettier
-#     npm link prettier
-
-#     # Install clean
-#     npm install -g clean
-#     npm link clean
-
-# elif [ "$USE_YARN" == true ]; then
-#     # Install typescript
-#     yarn add -D typescript
-#     yarn link typescript
-
-#     # Install eslint
-#     yarn global add eslint
-#     yarn link eslint
-
-#     # Install prettier
-#     yarn global add prettier
-#     yarn link prettier
-
-#     # Install clean
-#     yarn global add clean
-#     yarn link clean
-    
-# elif [ "$USE_PNPM" == true ]; then
-#     # Install typescript
-#     pnpm add -D typescript
-#     pnpm link typescript
-
-#     # Install eslint
-#     pnpm add -g eslint
-#     pnpm link eslint
-
-#     # Install prettier
-#     pnpm add -g prettier
-#     pnpm link prettier
-
-#     # Install clean
-#     pnpm add -g clean
-#     pnpm link clean
-# fi
-
 # Check SonarQube
 curl --noproxy $NO_PROXY -I --insecure $SONAR_URL/about
 curl --noproxy $NO_PROXY --insecure -X POST -u $SONAR_APIKEY: "$( echo "$SONAR_URL/api/projects/create?&project=$COMPONENT_ID&name="$COMPONENT_NAME"" | sed 's/ /%20/g' )"
 curl --noproxy $NO_PROXY --insecure -X POST -u $SONAR_APIKEY: "$SONAR_URL/api/qualitygates/select?projectKey=$COMPONENT_ID&gateId=$SONAR_GATEID"
 
 # Install sonar-scanner
-curl --insecure -o /opt/sonarscanner.zip -L https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.0.0.1744.zip
+curl --insecure -o /opt/sonarscanner.zip -L https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.7.0.2747.zip
 unzip -o /opt/sonarscanner.zip -d /opt
 SONAR_FOLDER=`ls /opt | grep sonar-scanner`
 SONAR_HOME=/opt/$SONAR_FOLDER
@@ -134,7 +83,7 @@ if [[ -d "./node_modules/jest" ]]; then
         yarn add -D $TEST_REPORTER
     elif [[ "$USE_PNPM" == true ]]; then
         echo "Installing $TEST_REPORTER"
-        COMMAND_ARGS="--testResultsProcessor $TEST_REPORTER"
+        COMMAND_ARGS="-- --testResultsProcessor $TEST_REPORTER"
         pnpm i -D $TEST_REPORTER
     fi
 fi
@@ -166,7 +115,7 @@ echo "NODE_PATH=$NODE_PATH"
 
 SONAR_FLAGS="$SONAR_FLAGS -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info"
 
-$SONAR_HOME/bin/sonar-scanner -Dsonar.host.url=$SONAR_URL -Dsonar.sources=$SRC_FOLDER -Dsonar.login=$SONAR_APIKEY -Dsonar.projectKey=$COMPONENT_ID -Dsonar.projectName="$COMPONENT_NAME" -Dsonar.projectVersion=$VERSION_NAME -Dsonar.scm.disabled=true -Dsonar.nodejs.executable=$NODE_PATH -Dsonar.javascript.node.maxspace=8192 $SONAR_FLAGS
+$SONAR_HOME/bin/sonar-scanner -Dsonar.host.url=$SONAR_URL -Dsonar.sources=$SRC_FOLDER -Dsonar.login=$SONAR_APIKEY -Dsonar.projectKey=$COMPONENT_ID -Dsonar.projectName="$COMPONENT_NAME" -Dsonar.projectVersion=$VERSION_NAME -Dsonar.nodejs.executable=$NODE_PATH -Dsonar.scm.disabled=true -Dsonar.javascript.node.maxspace=8192 $SONAR_FLAGS
 
 EXIT_CODE=$?
 echo "EXIT_CODE=$EXIT_CODE"


### PR DESCRIPTION
Closes #10 

Support for pnpm package manager in build and test activities. 

> Note: caching is not enabled in CICD so install speed improvements won't be gained with this release.

## Changelog

### New

- support  [pnpm](https://pnpm.io/) package manager
- add testing for `npm` lib component mode
- add support for nvm testing with npm/yarn/pnpm
- add support for npm package publishing
- add support for npm package testing

### Changed

- build and test scripts to all respect the `language.version` and `build.tool` properties for the component
- format of strings for script execution for readability

### Removed

- Nada

## Testing / Reviewing

Build and test a component with the following properties set:

```
build.tool=pnpm
feature.node.nvm=true
language.version=16
```

