### PR TITLE
add --max-old-space-size=8192 to NODE_OPTIONS

### DIFF
--- a/scripts/build/compile-node.sh
+++ b/scripts/build/compile-node.sh
@@ -20,6 +20,9 @@ else
     echo "Setting build script to $BUILD_SCRIPT..."
 fi
 
+# Set JS heap space
+export NODE_OPTIONS="--max-old-space-size=8192"
+
 # This needs to be checking for undefined as thats whats returned by the node command
 SCRIPT=$(node -pe "require('./package.json').scripts.$BUILD_SCRIPT");
 if [ "$SCRIPT" != "undefined" ]; then
@@ -32,4 +35,3 @@ else
     # Allow Node.js components to not have a build step
     echo "npm script ($BUILD_SCRIPT) not defined in the package.json file. Skipping..."
 fi
-

--- a/scripts/build/compile-package-npm.sh
+++ b/scripts/build/compile-package-npm.sh
@@ -30,6 +30,9 @@ if [ "$DEBUG" == "true" ]; then
     DEBUG_OPTS+="--verbose"
 fi
 
+# Set JS heap space
+export NODE_OPTIONS="--max-old-space-size=8192"
+
 curl -k -v -u $ART_USER:$ART_PASSWORD $ART_URL/api/npm/boomeranglib-npm/auth/"${SCOPE:1}" -o .npmrc
 npm publish --registry $ART_URL/api/npm/boomeranglib-npm/ $DEBUG_OPTS
 RESULT=$?


### PR DESCRIPTION
Add export `NODE_OPTIONS=--max-old-space-size=8192 to NODE_OPTIONS` to cater for Node.js builds requiring larger than default JS heap space