### PR TITLE
Fix sq node

### DIFF
--- a/Dockerfile-node-ubuntu
+++ b/Dockerfile-node-ubuntu
@@ -6,6 +6,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Prevent dialog during apt install
 ENV DEBIAN_FRONTEND noninteractive
+ENV DEBCONF_NOWARNINGS="yes"
 
 WORKDIR /opt/bin
 

--- a/commands/test.js
+++ b/commands/test.js
@@ -83,7 +83,7 @@ module.exports = {
 
     try {
       log.ci("Initializing Dependencies");
-      await exec(`${shellDir}/common/initialize.sh`);      
+      await exec(`${shellDir}/common/initialize.sh`);
       await exec(`${shellDir}/common/initialize-dependencies-java-tool.sh ${taskParams["buildTool"]} ${taskParams["buildToolVersion"]}`);
 
       if (buildTool === "maven") {
@@ -111,7 +111,7 @@ module.exports = {
       }
 
       log.debug("Testing artifacts");
-      await exec(`${shellDir}/common/initialize-dependencies-java.sh ${taskParams["languageVersion"]}`);  
+      await exec(`${shellDir}/common/initialize-dependencies-java.sh ${taskParams["languageVersion"]}`);
       if (testTypes.includes(TestType.Static)) {
         log.debug("Commencing static tests");
         shell.cd(workdir);
@@ -127,7 +127,7 @@ module.exports = {
         ${taskParams["artifactoryUser"]} \
         ${taskParams["artifactoryPassword"]} \
         `);
-      }      
+      }
       await exec(`${shellDir}/common/initialize-dependencies-java.sh ${taskParams["languageVersion"]}`);
       if (testTypes.includes(TestType.Unit)) {
         log.debug("Commencing unit tests");
@@ -403,20 +403,6 @@ module.exports = {
       ${taskParams["buildTool"]} \
       ${taskParams["cypressInstallBinary"]}`);
 
-      if (testTypes.includes(TestType.Unit)) {
-        log.debug("Commencing unit tests");
-        await exec(`${shellDir}/test/unit-node.sh \
-        ${taskParams["languageVersion"]} \
-        ${taskParams["buildTool"]} \
-        ${version} \
-        ${taskParams["sonarUrl"]} \
-        ${taskParams["sonarApiKey"]} \
-        ${taskParams["systemComponentId"]} \
-        ${taskParams["systemComponentName"]} \\
-        ${JSON.stringify(taskParams["artifactoryUrl"])} \
-        ${taskParams["artifactoryUser"]} \
-        ${taskParams["artifactoryPassword"]}`);
-      }
       if (testTypes.includes(TestType.Static)) {
         log.debug("Commencing static tests");
         await exec(`${shellDir}/test/static-node.sh \
@@ -427,6 +413,21 @@ module.exports = {
         ${taskParams["sonarApiKey"]} \
         ${taskParams["systemComponentId"]} \
         ${taskParams["systemComponentName"]} \
+        ${JSON.stringify(taskParams["artifactoryUrl"])} \
+        ${taskParams["artifactoryUser"]} \
+        ${taskParams["artifactoryPassword"]}`);
+      }
+
+      if (testTypes.includes(TestType.Unit)) {
+        log.debug("Commencing unit tests");
+        await exec(`${shellDir}/test/unit-node.sh \
+        ${taskParams["languageVersion"]} \
+        ${taskParams["buildTool"]} \
+        ${version} \
+        ${taskParams["sonarUrl"]} \
+        ${taskParams["sonarApiKey"]} \
+        ${taskParams["systemComponentId"]} \
+        ${taskParams["systemComponentName"]} \\
         ${JSON.stringify(taskParams["artifactoryUrl"])} \
         ${taskParams["artifactoryUser"]} \
         ${taskParams["artifactoryPassword"]}`);

--- a/commands/test.js
+++ b/commands/test.js
@@ -430,8 +430,9 @@ module.exports = {
         ${JSON.stringify(taskParams["artifactoryUrl"])} \
         ${taskParams["artifactoryUser"]} \
         ${taskParams["artifactoryPassword"]} \
-        ${taskParams["userInclusions"]} \
-        ${taskParams["userExclusions"]}`);
+        ${taskParams["codeCovInclusions"]} \
+        ${taskParams["codeCovExclusions"]} \
+        ${taskParams["codeCovIncludeAll"]}`);
       }
       if (testTypes.includes(TestType.Security)) {
         log.debug("Commencing security tests");
@@ -569,8 +570,9 @@ module.exports = {
         ${JSON.stringify(taskParams["artifactoryUrl"])} \
         ${taskParams["artifactoryUser"]} \
         ${taskParams["artifactoryPassword"]} \
-        ${taskParams["userInclusions"]} \
-        ${taskParams["userExclusions"]}`);
+        ${taskParams["codeCovInclusions"]} \
+        ${taskParams["codeCovExclusions"]} \
+        ${taskParams["codeCovIncludeAll"]}`);
       }
       if (testTypes.includes(TestType.Security)) {
         log.debug("Commencing security tests");

--- a/commands/test.js
+++ b/commands/test.js
@@ -429,7 +429,9 @@ module.exports = {
         ${taskParams["systemComponentName"]} \\
         ${JSON.stringify(taskParams["artifactoryUrl"])} \
         ${taskParams["artifactoryUser"]} \
-        ${taskParams["artifactoryPassword"]}`);
+        ${taskParams["artifactoryPassword"]} \        
+        ${taskParams["userInclusions"]} \
+        ${taskParams["userExclusions"]}`);
       }
       if (testTypes.includes(TestType.Security)) {
         log.debug("Commencing security tests");

--- a/commands/test.js
+++ b/commands/test.js
@@ -430,9 +430,9 @@ module.exports = {
         ${JSON.stringify(taskParams["artifactoryUrl"])} \
         ${taskParams["artifactoryUser"]} \
         ${taskParams["artifactoryPassword"]} \
-        ${taskParams["codeCovInclusions"]} \
-        ${taskParams["codeCovExclusions"]} \
-        ${taskParams["codeCovIncludeAll"]}`);
+        "${taskParams["codeCovInclusions"]}" \
+        "${taskParams["codeCovExclusions"]}" \
+        "${taskParams["codeCovIncludeAll"]}"`);
       }
       if (testTypes.includes(TestType.Security)) {
         log.debug("Commencing security tests");
@@ -570,9 +570,9 @@ module.exports = {
         ${JSON.stringify(taskParams["artifactoryUrl"])} \
         ${taskParams["artifactoryUser"]} \
         ${taskParams["artifactoryPassword"]} \
-        ${taskParams["codeCovInclusions"]} \
-        ${taskParams["codeCovExclusions"]} \
-        ${taskParams["codeCovIncludeAll"]}`);
+        "${taskParams["codeCovInclusions"]}" \
+        "${taskParams["codeCovExclusions"]}" \
+        "${taskParams["codeCovIncludeAll"]}"`);
       }
       if (testTypes.includes(TestType.Security)) {
         log.debug("Commencing security tests");

--- a/commands/test.js
+++ b/commands/test.js
@@ -429,7 +429,7 @@ module.exports = {
         ${taskParams["systemComponentName"]} \
         ${JSON.stringify(taskParams["artifactoryUrl"])} \
         ${taskParams["artifactoryUser"]} \
-        ${taskParams["artifactoryPassword"]} \        
+        ${taskParams["artifactoryPassword"]} \
         ${taskParams["userInclusions"]} \
         ${taskParams["userExclusions"]}`);
       }
@@ -568,9 +568,9 @@ module.exports = {
         ${taskParams["systemComponentName"]} \
         ${JSON.stringify(taskParams["artifactoryUrl"])} \
         ${taskParams["artifactoryUser"]} \
-        ${taskParams["artifactoryPassword"]} \        
+        ${taskParams["artifactoryPassword"]} \
         ${taskParams["userInclusions"]} \
-        ${taskParams["userExclusions"]}`);        
+        ${taskParams["userExclusions"]}`);
       }
       if (testTypes.includes(TestType.Security)) {
         log.debug("Commencing security tests");

--- a/commands/test.js
+++ b/commands/test.js
@@ -426,7 +426,7 @@ module.exports = {
         ${taskParams["sonarUrl"]} \
         ${taskParams["sonarApiKey"]} \
         ${taskParams["systemComponentId"]} \
-        ${taskParams["systemComponentName"]} \\
+        ${taskParams["systemComponentName"]} \
         ${JSON.stringify(taskParams["artifactoryUrl"])} \
         ${taskParams["artifactoryUser"]} \
         ${taskParams["artifactoryPassword"]} \        
@@ -565,7 +565,12 @@ module.exports = {
         ${taskParams["sonarUrl"]} \
         ${taskParams["sonarApiKey"]} \
         ${taskParams["systemComponentId"]} \
-        ${taskParams["systemComponentName"]}`);
+        ${taskParams["systemComponentName"]} \
+        ${JSON.stringify(taskParams["artifactoryUrl"])} \
+        ${taskParams["artifactoryUser"]} \
+        ${taskParams["artifactoryPassword"]} \        
+        ${taskParams["userInclusions"]} \
+        ${taskParams["userExclusions"]}`);        
       }
       if (testTypes.includes(TestType.Security)) {
         log.debug("Commencing security tests");

--- a/commands/test.js
+++ b/commands/test.js
@@ -417,7 +417,6 @@ module.exports = {
         ${taskParams["artifactoryUser"]} \
         ${taskParams["artifactoryPassword"]}`);
       }
-
       if (testTypes.includes(TestType.Unit)) {
         log.debug("Commencing unit tests");
         await exec(`${shellDir}/test/unit-node.sh \

--- a/commands/test.js
+++ b/commands/test.js
@@ -403,7 +403,7 @@ module.exports = {
       ${taskParams["buildTool"]} \
       ${taskParams["cypressInstallBinary"]}`);
 
-      if (testTypes.includes(TestType.Static)) {
+      if (testTypes.includes(TestType.Static) && !testTypes.includes(TestType.Unit)) {
         log.debug("Commencing static tests");
         await exec(`${shellDir}/test/static-node.sh \
         ${taskParams["languageVersion"]} \
@@ -543,7 +543,7 @@ module.exports = {
       ${taskParams["buildTool"]} \
       ${taskParams["cypressInstallBinary"]}`);
 
-      if (testTypes.includes(TestType.Static)) {
+      if (testTypes.includes(TestType.Static) && !testTypes.includes(TestType.Unit)) {
         log.debug("Commencing static tests");
         await exec(`${shellDir}/test/static-node.sh \
         ${taskParams["languageVersion"]} \

--- a/scripts/test/static-node.sh
+++ b/scripts/test/static-node.sh
@@ -40,9 +40,11 @@ nvm use $LANGUAGE_VERSION
 [[ "$BUILD_TOOL" == "pnpm" ]] && USE_PNPM=true || USE_PNPM=false
 
 if [ "$USE_NPM" == false ] && [ "$USE_YARN" == false ] && [ "$USE_PNPM" == false ]; then
-    echo "build tool not specified, defaulting to 'npm'..."
+    echo "Build tool not specified, defaulting to 'npm'..."
     BUILD_TOOL="npm"
 fi
+
+echo "Using build tool $BUILD_TOOL"
 
 # Set JS heap space
 export NODE_OPTIONS="--max-old-space-size=8192"
@@ -53,6 +55,7 @@ curl --noproxy $NO_PROXY --insecure -X POST -u $SONAR_APIKEY: "$( echo "$SONAR_U
 curl --noproxy $NO_PROXY --insecure -X POST -u $SONAR_APIKEY: "$SONAR_URL/api/qualitygates/select?projectKey=$COMPONENT_ID&gateId=$SONAR_GATEID"
 
 # Install sonar-scanner
+# TODO: should be a CICD system property
 echo "Installing sonar-scanner"
 echo "$ART_URL/boomerang/software/sonarqube/sonar-scanner-cli-4.8.0.2856.zip"
 curl --insecure -o /opt/sonarscanner.zip -L -u $ART_USER:$ART_PASSWORD $ART_URL/boomerang/software/sonarqube/sonar-scanner-cli-4.8.0.2856.zip
@@ -90,7 +93,7 @@ elif [ -d "src" ]; then
     echo "Source folder 'src' exists."
     SRC_FOLDER=src
 else
-    echo "Source folder 'src' does not exist - defaulting to root folder of project and will scan all sub-folders."
+    echo "Source folder 'src' does not exist - defaulting to the current folder and will scan all sub-folders."
     SRC_FOLDER=.
 
     # Using root location as src folder means we will have a clash with worker.cicd folders so let's exclude those too

--- a/scripts/test/static-node.sh
+++ b/scripts/test/static-node.sh
@@ -93,7 +93,7 @@ elif [ -d "src" ]; then
     echo "Source folder 'src' exists."
     SRC_FOLDER=src
 else
-    echo "Source folder 'src' does not exist - defaulting to the current folder and will scan all sub-folders."
+    echo "Source folder 'src' does not exist - defaulting to the current folder and will scan all sub-folders." 
     SRC_FOLDER=.
 
     # Using root location as src folder means we will have a clash with worker.cicd folders so let's exclude those too

--- a/scripts/test/static-node.sh
+++ b/scripts/test/static-node.sh
@@ -66,10 +66,13 @@ fi
 
 # Run linting script
 SCRIPT=$(node -pe "require('./package.json').scripts.lint");
-if [[ "$SCRIPT" != "undefined" ]]; then
-    npm run lint
-    SONAR_FLAGS="$SONAR_FLAGS -Dsonar.eslint.reportPaths=lint-report.json"
-    ls -al lint-report.json
+ESLINT_DEP=$(node -pe "require('./package.json').dependencies.eslint");
+ESLINT_DEV_DEP=$(node -pe "require('./package.json').devDependencies.eslint");
+if [ "$SCRIPT" != "undefined" ] && [[ "$ESLINT_DEP" != "undefined" || "$ESLINT_DEV_DEP" != "undefined" ]]; then
+    LINT_REPORT=lint-report.json
+    npm run lint -- -f json -o $LINT_REPORT
+    SONAR_FLAGS="$SONAR_FLAGS -Dsonar.eslint.reportPaths=$LINT_REPORT"
+    ls -al $LINT_REPORT
 fi
 echo "SONAR_FLAGS=$SONAR_FLAGS"
 

--- a/scripts/test/unit-node.sh
+++ b/scripts/test/unit-node.sh
@@ -118,7 +118,8 @@ if [[ "$TEST_SCRIPT" != "undefined" ]]; then
             fi
         fi
 
-        COVERAGE_PROVIDER_DEP="@vitest/coverage-c8"
+        VITEST_VERSION=$(node -pe "require('./package.json').devDependencies.vitest");
+        COVERAGE_PROVIDER_DEP="@vitest/coverage-c8@$VITEST_VERSION"
         if [[ ! -d "./node_modules/$COVERAGE_PROVIDER_DEP" ]]; then
             if [[ "$USE_NPM" == true ]]; then
                 echo "Installing $COVERAGE_PROVIDER_DEP"
@@ -134,7 +135,6 @@ if [[ "$TEST_SCRIPT" != "undefined" ]]; then
     fi
 
     npm test $COMMAND_ARGS
-
 fi
 
 # Run 'lint'

--- a/scripts/test/unit-node.sh
+++ b/scripts/test/unit-node.sh
@@ -14,11 +14,11 @@ ART_URL=$8
 ART_USER=$9
 ART_PASSWORD=${10}
 
-# Fail fast if testing script is not present
-SCRIPT=$(node -pe "require('./package.json').scripts.test");
-if [[ "$SCRIPT" == "undefined" ]]; then
-    echo "'test' script not defined in the package.json file"
-    exit 95
+# Fail fast if both test and lint scripts are not present
+TEST_SCRIPT=$(node -pe "require('./package.json').scripts.test");
+LINT_SCRIPT=$(node -pe "require('./package.json').scripts.lint");
+if [ "$TEST_SCRIPT" == "undefined" ] && [ "$LINT_SCRIPT" == "undefined" ]; then
+    echo "'test' and 'lint' scripts are not defined in the package.json file. Running default scan from SonarQube."
 fi
 
 # Dependency for sonarscanner
@@ -62,99 +62,125 @@ curl --noproxy $NO_PROXY --insecure -X POST -u $SONAR_APIKEY: "$SONAR_URL/api/qu
 
 # Install sonar-scanner
 # TODO: should be a CICD system property
-# Install sonar-scanner
 echo "Installing sonar-scanner"
 echo "$ART_URL/boomerang/software/sonarqube/sonar-scanner-cli-4.8.0.2856.zip"
 curl --insecure -o /opt/sonarscanner.zip -L -u $ART_USER:$ART_PASSWORD $ART_URL/boomerang/software/sonarqube/sonar-scanner-cli-4.8.0.2856.zip
 unzip -o /opt/sonarscanner.zip -d /opt
 SONAR_FOLDER=`ls /opt | grep sonar-scanner`
 SONAR_HOME=/opt/$SONAR_FOLDER
+SONAR_FLAGS=
 if [ "$DEBUG" == "true" ]; then
     SONAR_FLAGS="-Dsonar.verbose=true"
-else
-    SONAR_FLAGS=
 fi
 
-# Check that jest exists and that it is being used in the script, either directly or through CRA
-if [[ -d "./node_modules/jest" && "$SCRIPT" == *react-scripts* || "$SCRIPT" == *jest* ]]; then
-    TEST_REPORTER="jest-sonar-reporter"
-    SONAR_FLAGS="$SONAR_FLAGS -Dsonar.testExecutionReportPaths=test-report.xml"
-    SONAR_FLAGS="$SONAR_FLAGS -Dsonar.tests=src"
+# Run 'test'
+if [[ "$TEST_SCRIPT" != "undefined"]]; then
+    # Check that jest exists and that it is being used in the script, either directly or through CRA
+    if [[ -d "./node_modules/jest" && "$SCRIPT" == *react-scripts* || "$SCRIPT" == *jest* ]]; then
+        TEST_REPORTER="jest-sonar-reporter"
+        SONAR_FLAGS="$SONAR_FLAGS -Dsonar.testExecutionReportPaths=test-report.xml"
+        SONAR_FLAGS="$SONAR_FLAGS -Dsonar.tests=src"
 
-    # Support Typscript and other common naming standards
-    SONAR_FLAGS="$SONAR_FLAGS -Dsonar.test.inclusions=**/*.test.tsx,**/*.test.ts,**/*.test.jsx,**/*.test.js,**/*.spec.tsx,**/*.spec.ts,**/*.spec.js,**/*.spec.tsx"
-    if [[ "$USE_NPM" == true ]]; then
-        echo "Installing $TEST_REPORTER"
-        COMMAND_ARGS="-- --testResultsProcessor $TEST_REPORTER --coverage"
-        npm i -D $TEST_REPORTER
-    elif [[ "$USE_YARN" == true ]]; then
-        echo "Installing $TEST_REPORTER"
-        COMMAND_ARGS="--testResultsProcessor $TEST_REPORTER --coverage"
-        yarn add -D $TEST_REPORTER
-    elif [[ "$USE_PNPM" == true ]]; then
-        echo "Installing $TEST_REPORTER"
-        COMMAND_ARGS="-- --testResultsProcessor $TEST_REPORTER --coverage"
-        pnpm i -D $TEST_REPORTER
-    fi
-fi
-
-# Check that vitest exists and that it is being used in the script
-if [[ -d "./node_modules/vitest" && "$SCRIPT" == *vitest* ]]; then
-    TEST_REPORTER="vitest-sonar-reporter"
-    SONAR_FLAGS="$SONAR_FLAGS -Dsonar.testExecutionReportPaths=test-report.xml"
-    SONAR_FLAGS="$SONAR_FLAGS -Dsonar.tests=src"
-
-    # Support Typscript and other common naming standards
-    SONAR_FLAGS="$SONAR_FLAGS -Dsonar.test.inclusions=**/*.test.tsx,**/*.test.ts,**/*.test.jsx,**/*.test.js,**/*.spec.tsx,**/*.spec.ts,**/*.spec.js,**/*.spec.tsx"
-    if [[ "$USE_NPM" == true ]]; then
-        COMMAND_ARGS="-- --reporter $TEST_REPORTER --outputFile test-report.xml --coverage"
-        if [[ ! -d "./node_modules/vitest-sonar-reporter" ]]; then
+        # Support Typscript and other common naming standards
+        SONAR_FLAGS="$SONAR_FLAGS -Dsonar.test.inclusions=**/*.test.tsx,**/*.test.ts,**/*.test.jsx,**/*.test.js,**/*.spec.tsx,**/*.spec.ts,**/*.spec.js,**/*.spec.tsx"
+        if [[ "$USE_NPM" == true ]]; then
             echo "Installing $TEST_REPORTER"
+            COMMAND_ARGS="-- --testResultsProcessor $TEST_REPORTER --coverage"
             npm i -D $TEST_REPORTER
-        fi
-    elif [[ "$USE_YARN" == true ]]; then
-        COMMAND_ARGS="--reporter $TEST_REPORTER --outputFile test-report.xml --coverage"
-        if [[ ! -d "./node_modules/vitest-sonar-reporter" ]]; then
+        elif [[ "$USE_YARN" == true ]]; then
             echo "Installing $TEST_REPORTER"
+            COMMAND_ARGS="--testResultsProcessor $TEST_REPORTER --coverage"
             yarn add -D $TEST_REPORTER
-        fi
-    elif [[ "$USE_PNPM" == true ]]; then
-        COMMAND_ARGS="-- --reporter $TEST_REPORTER --outputFile test-report.xml --coverage"
-        if [[ ! -d "./node_modules/vitest-sonar-reporter" ]]; then
+        elif [[ "$USE_PNPM" == true ]]; then
             echo "Installing $TEST_REPORTER"
+            COMMAND_ARGS="-- --testResultsProcessor $TEST_REPORTER --coverage"
             pnpm i -D $TEST_REPORTER
         fi
     fi
+
+    # Check that vitest exists and that it is being used in the script
+    if [[ -d "./node_modules/vitest" && "$SCRIPT" == *vitest* ]]; then
+        TEST_REPORTER="vitest-sonar-reporter"
+        SONAR_FLAGS="$SONAR_FLAGS -Dsonar.testExecutionReportPaths=test-report.xml"
+        SONAR_FLAGS="$SONAR_FLAGS -Dsonar.tests=src"
+
+        # Support Typscript and other common naming standards
+        SONAR_FLAGS="$SONAR_FLAGS -Dsonar.test.inclusions=**/*.test.tsx,**/*.test.ts,**/*.test.jsx,**/*.test.js,**/*.spec.tsx,**/*.spec.ts,**/*.spec.js,**/*.spec.tsx"
+        if [[ "$USE_NPM" == true ]]; then
+            COMMAND_ARGS="-- --reporter $TEST_REPORTER --outputFile test-report.xml --coverage"
+            if [[ ! -d "./node_modules/vitest-sonar-reporter" ]]; then
+                echo "Installing $TEST_REPORTER"
+                npm i -D $TEST_REPORTER
+            fi
+        elif [[ "$USE_YARN" == true ]]; then
+            COMMAND_ARGS="--reporter $TEST_REPORTER --outputFile test-report.xml --coverage"
+            if [[ ! -d "./node_modules/vitest-sonar-reporter" ]]; then
+                echo "Installing $TEST_REPORTER"
+                yarn add -D $TEST_REPORTER
+            fi
+        elif [[ "$USE_PNPM" == true ]]; then
+            COMMAND_ARGS="-- --reporter $TEST_REPORTER --outputFile test-report.xml --coverage"
+            if [[ ! -d "./node_modules/vitest-sonar-reporter" ]]; then
+                echo "Installing $TEST_REPORTER"
+                pnpm i -D $TEST_REPORTER
+            fi
+        fi
+    fi
+
+    if [[ "$USE_NPM" == true ]]; then
+        # npm clean-install
+        npm test $COMMAND_ARGS
+    elif [[ "$USE_YARN" == true ]]; then
+        yarn test $COMMAND_ARGS
+    elif [[ "$USE_PNPM" == true ]]; then
+        pnpm test $COMMAND_ARGS
+    fi
 fi
 
-if [[ "$USE_NPM" == true ]]; then
-    # npm clean-install
-    npm test $COMMAND_ARGS
-elif [[ "$USE_YARN" == true ]]; then
-    yarn test $COMMAND_ARGS
-elif [[ "$USE_PNPM" == true ]]; then
-    pnpm test $COMMAND_ARGS
+# Run 'lint'
+if [[ "$LINT_SCRIPT" != "undefined"]]; then
+    SCRIPT=$(node -pe "require('./package.json').scripts.lint");
+    ESLINT_DEP=$(node -pe "require('./package.json').dependencies.eslint");
+    ESLINT_DEV_DEP=$(node -pe "require('./package.json').devDependencies.eslint");
+    if [ "$SCRIPT" != "undefined" ] && [[ "$ESLINT_DEP" != "undefined" || "$ESLINT_DEV_DEP" != "undefined" ]]; then
+        LINT_REPORT=lint-report.json
+        COVERAGE_REPORT=coverage/lcov.info
+        npm run lint -- -f json -o $LINT_REPORT
+        SONAR_FLAGS="$SONAR_FLAGS -Dsonar.eslint.reportPaths=$LINT_REPORT -Dsonar.javascript.lcov.reportPaths=$COVERAGE_REPORT"
+        ls -al $LINT_REPORT
+    fi
+    echo "SONAR_FLAGS=$SONAR_FLAGS"
 fi
+
+# Set SonarQube scanning exclusions
+SONAR_EXCLUSIONS=-Dsonar.exclusions=**/node_modules/**
+# Place setter for new IF statement to handle user specified exclusions
+# SONAR_EXCLUSIONS="$SONAR_EXCLUSIONS,$USER_EXCLUSIONS"
+echo "SONAR_EXCLUSIONS=$SONAR_EXCLUSIONS"
 
 SRC_FOLDER=
 if [ -d "dist" ]; then
     echo "Source folder 'dist' exists."
-    SRC_FOLDER=src
+    SRC_FOLDER=dist
 elif [ -d "src" ]; then
     echo "Source folder 'src' exists."
     SRC_FOLDER=src
 else
-    echo "Source folder 'src' does not exist - defaulting to root folder of project and will scan all sub-folders."
+    echo "Source folder 'src' does not exist - defaulting to the current folder and will scan all sub-folders."
     SRC_FOLDER=.
+
+     # Using root location as src folder means we will have a clash with worker.cicd folders so let's exclude those too
+    echo "Append worker.cicd sub-folders to exclusions so they are not scanned by SonarQube."
+    SONAR_EXCLUSIONS="$SONAR_EXCLUSIONS,/commands/**,/scripts/**"
+    echo "SONAR_EXCLUSIONS=$SONAR_EXCLUSIONS"
 fi
+echo "SRC_FOLDER=$SRC_FOLDER"
 
 # Set Node.js bin path
 NODE_PATH=$(which node)
 echo "NODE_PATH=$NODE_PATH"
 
-SONAR_FLAGS="$SONAR_FLAGS -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info"
-
-$SONAR_HOME/bin/sonar-scanner -Dsonar.host.url=$SONAR_URL -Dsonar.sources=$SRC_FOLDER -Dsonar.login=$SONAR_APIKEY -Dsonar.projectKey=$COMPONENT_ID -Dsonar.projectName="$COMPONENT_NAME" -Dsonar.projectVersion=$VERSION_NAME -Dsonar.nodejs.executable=$NODE_PATH -Dsonar.scm.disabled=true -Dsonar.javascript.node.maxspace=8192 $SONAR_FLAGS
+$SONAR_HOME/bin/sonar-scanner -Dsonar.host.url=$SONAR_URL -Dsonar.sources=$SRC_FOLDER -Dsonar.login=$SONAR_APIKEY -Dsonar.projectKey=$COMPONENT_ID -Dsonar.projectName="$COMPONENT_NAME" -Dsonar.projectVersion=$VERSION_NAME -Dsonar.nodejs.executable=$NODE_PATH -Dsonar.scm.disabled=true -Dsonar.javascript.node.maxspace=8192 $SONAR_EXCLUSIONS $SONAR_FLAGS
 
 EXIT_CODE=$?
 echo "EXIT_CODE=$EXIT_CODE"

--- a/scripts/test/unit-node.sh
+++ b/scripts/test/unit-node.sh
@@ -101,8 +101,9 @@ if [[ "$TEST_SCRIPT" != "undefined" ]]; then
 
     # Check that vitest exists and that it is being used in the script
     if [[ -d "./node_modules/vitest" && "$TEST_SCRIPT" == *vitest* ]]; then
-        TEST_REPORTER="vitest-sonar-reporter"
         COVERAGE_PROVIDER="c8"
+        COVERAGE_REPORTER="lcov"
+        TEST_REPORTER="vitest-sonar-reporter"
         COMMAND_ARGS="-- --coverage.enabled --reporter=$TEST_REPORTER --outputFile=$UNIT_TEST_REPORT_NAME --coverage.reporter=$COVERAGE_REPORTER --coverage.provider=$COVERAGE_PROVIDER"
         if [[ ! -d "./node_modules/$TEST_REPORTER" ]]; then
             if [[ "$USE_NPM" == true ]]; then

--- a/scripts/test/unit-node.sh
+++ b/scripts/test/unit-node.sh
@@ -106,7 +106,6 @@ if [[ "$TEST_SCRIPT" != "undefined" ]]; then
         TEST_REPORTER="vitest-sonar-reporter"
         COMMAND_ARGS="-- --coverage.enabled --reporter=$TEST_REPORTER --outputFile=$UNIT_TEST_REPORT_NAME --coverage.reporter=$COVERAGE_REPORTER --coverage.provider=$COVERAGE_PROVIDER"
 
-
         if [[ ! -d "./node_modules/$TEST_REPORTER" ]]; then
             if [[ "$USE_NPM" == true ]]; then
                 echo "Installing $TEST_REPORTER"

--- a/scripts/test/unit-node.sh
+++ b/scripts/test/unit-node.sh
@@ -109,13 +109,21 @@ if [[ "$TEST_SCRIPT" != "undefined" ]]; then
         COMMAND_ARGS="-- --coverage.enabled --reporter=$TEST_REPORTER --outputFile=$UNIT_TEST_REPORT_NAME --coverage.reporter=$COVERAGE_REPORTER --coverage.provider=$COVERAGE_PROVIDER --coverage.all=true"
         echo "USER_INCLUSIONS=[$USER_INCLUSIONS]"
         if [[ "$USER_INCLUSIONS" != "undefined" && "$USER_INCLUSIONS" != "" ]]; then
-            COMMAND_ARGS="$COMMAND_ARGS --coverage.include=$USER_INCLUSIONS"
+            IFS=',' read -ra USER_INCLUSIONS_LIST <<< "$USER_INCLUSIONS"
+            for USER_INCLUSION in "${USER_INCLUSIONS_LIST[@]}"
+            do
+                COMMAND_ARGS="$COMMAND_ARGS --coverage.include=$USER_INCLUSION"
+            done   
         else
             COMMAND_ARGS="$COMMAND_ARGS --coverage.include=src"
         fi
         echo "USER_EXCLUSIONS=[$USER_EXCLUSIONS]"
         if [[ "$USER_EXCLUSIONS" != "undefined" && "$USER_EXCLUSIONS" != "" ]]; then
-            COMMAND_ARGS="$COMMAND_ARGS --coverage.exclude=$USER_EXCLUSIONS"
+            IFS=',' read -ra USER_EXCLUSIONS_LIST <<< "$USER_EXCLUSIONS"
+            for USER_EXCLUSION in "${USER_EXCLUSIONS_LIST[@]}"
+            do
+                COMMAND_ARGS="$COMMAND_ARGS --coverage.exclude=$USER_EXCLUSION"
+            done           
         fi
         
         if [[ ! -d "./node_modules/$TEST_REPORTER" ]]; then

--- a/scripts/test/unit-node.sh
+++ b/scripts/test/unit-node.sh
@@ -13,6 +13,8 @@ COMPONENT_NAME=$7
 ART_URL=$8
 ART_USER=$9
 ART_PASSWORD=${10}
+USER_INCLUSIONS=${11}
+USER_EXCLUSIONS=${12}
 
 # Fail fast if both test and lint scripts are not present
 TEST_SCRIPT=$(node -pe "require('./package.json').scripts.test");
@@ -103,9 +105,18 @@ if [[ "$TEST_SCRIPT" != "undefined" ]]; then
     if [[ -d "./node_modules/vitest" && "$TEST_SCRIPT" == *vitest* ]]; then
         COVERAGE_PROVIDER="c8"
         COVERAGE_REPORTER="lcov"
-        COVERAGE_INCLUDE="src"
+        COVERAGE_INCLUDE=
+        if [ "$USER_INCLUSIONS" != "undefined" ]; then
+            COVERAGE_INCLUDE=$USER_INCLUSIONS
+        else
+            COVERAGE_INCLUDE="src"
+        fi
+        COVERAGE_EXCLUDE=
+        if [ "$USER_EXCLUSIONS" != "undefined" ]; then
+            COVERAGE_EXCLUDE=$USER_EXCLUSIONS
+        fi
         TEST_REPORTER="vitest-sonar-reporter"
-        COMMAND_ARGS="-- --coverage.enabled --reporter=$TEST_REPORTER --outputFile=$UNIT_TEST_REPORT_NAME --coverage.reporter=$COVERAGE_REPORTER --coverage.provider=$COVERAGE_PROVIDER --coverage.include=$COVERAGE_INCLUDE"
+        COMMAND_ARGS="-- --coverage.enabled --reporter=$TEST_REPORTER --outputFile=$UNIT_TEST_REPORT_NAME --coverage.reporter=$COVERAGE_REPORTER --coverage.provider=$COVERAGE_PROVIDER --coverage.include=$COVERAGE_INCLUDE --coverage.exclude=$COVERAGE_EXCLUDE --coverage.all=true"
 
         if [[ ! -d "./node_modules/$TEST_REPORTER" ]]; then
             if [[ "$USE_NPM" == true ]]; then
@@ -141,7 +152,6 @@ if [[ "$TEST_SCRIPT" != "undefined" ]]; then
     COVERAGE_REPORT=coverage/lcov.info
     SONAR_FLAGS="$SONAR_FLAGS -Dsonar.javascript.lcov.reportPaths=$COVERAGE_REPORT"
     ls -al $COVERAGE_REPORT
-    cat $COVERAGE_REPORT
     echo "SONAR_FLAGS=$SONAR_FLAGS"
 fi
 

--- a/scripts/test/unit-node.sh
+++ b/scripts/test/unit-node.sh
@@ -105,15 +105,19 @@ if [[ "$TEST_SCRIPT" != "undefined" ]]; then
     if [[ -d "./node_modules/vitest" && "$TEST_SCRIPT" == *vitest* ]]; then
         COVERAGE_PROVIDER="c8"
         COVERAGE_REPORTER="lcov"
+        echo "USER_INCLUSIONS=$USER_INCLUSIONS"
         COVERAGE_INCLUDE=
         if [ "$USER_INCLUSIONS" != "undefined" ]; then
             COVERAGE_INCLUDE=$USER_INCLUSIONS
         else
-            COVERAGE_INCLUDE="src"
+            COVERAGE_INCLUDE="**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"
         fi
+        echo "USER_EXCLUSIONS=$USER_EXCLUSIONS"
         COVERAGE_EXCLUDE=
         if [ "$USER_EXCLUSIONS" != "undefined" ]; then
             COVERAGE_EXCLUDE=$USER_EXCLUSIONS
+        else
+            COVERAGE_EXCLUDE="**/node_modules/**,**/dist/**,**/cypress/**,**/.{idea,git,cache,output,temp}/**,**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*"
         fi
         TEST_REPORTER="vitest-sonar-reporter"
         COMMAND_ARGS="-- --coverage.enabled --reporter=$TEST_REPORTER --outputFile=$UNIT_TEST_REPORT_NAME --coverage.reporter=$COVERAGE_REPORTER --coverage.provider=$COVERAGE_PROVIDER --coverage.include=$COVERAGE_INCLUDE --coverage.exclude=$COVERAGE_EXCLUDE --coverage.all=true"

--- a/scripts/test/unit-node.sh
+++ b/scripts/test/unit-node.sh
@@ -197,8 +197,3 @@ NODE_PATH=$(which node)
 echo "NODE_PATH=$NODE_PATH"
 
 $SONAR_HOME/bin/sonar-scanner -Dsonar.host.url=$SONAR_URL -Dsonar.sources=$SRC_FOLDER -Dsonar.login=$SONAR_APIKEY -Dsonar.projectKey=$COMPONENT_ID -Dsonar.projectName="$COMPONENT_NAME" -Dsonar.projectVersion=$VERSION_NAME -Dsonar.nodejs.executable=$NODE_PATH -Dsonar.scm.disabled=true -Dsonar.javascript.node.maxspace=8192 $SONAR_EXCLUSIONS $SONAR_FLAGS
-
-EXIT_CODE=$?
-echo "EXIT_CODE=$EXIT_CODE"
-
-exit $EXIT_CODE

--- a/scripts/test/unit-node.sh
+++ b/scripts/test/unit-node.sh
@@ -103,6 +103,7 @@ if [[ "$TEST_SCRIPT" != "undefined" ]]; then
 
     # Check that vitest exists and that it is being used in the script
     if [[ -d "./node_modules/vitest" && "$TEST_SCRIPT" == *vitest* ]]; then
+        TEST_REPORTER="vitest-sonar-reporter"
         COVERAGE_PROVIDER="c8"
         COVERAGE_REPORTER="lcov"
         COMMAND_ARGS="-- --coverage.enabled --reporter=$TEST_REPORTER --outputFile=$UNIT_TEST_REPORT_NAME --coverage.reporter=$COVERAGE_REPORTER --coverage.provider=$COVERAGE_PROVIDER --coverage.all=true"
@@ -116,8 +117,7 @@ if [[ "$TEST_SCRIPT" != "undefined" ]]; then
         if [[ "$USER_EXCLUSIONS" != "undefined" && "$USER_EXCLUSIONS" != "" ]]; then
             COMMAND_ARGS="$COMMAND_ARGS --coverage.exclude=$USER_EXCLUSIONS"
         fi
-
-        TEST_REPORTER="vitest-sonar-reporter"      
+        
         if [[ ! -d "./node_modules/$TEST_REPORTER" ]]; then
             if [[ "$USE_NPM" == true ]]; then
                 echo "Installing $TEST_REPORTER"

--- a/scripts/test/unit-node.sh
+++ b/scripts/test/unit-node.sh
@@ -74,7 +74,7 @@ if [ "$DEBUG" == "true" ]; then
 fi
 
 # Run 'test'
-if [[ "$TEST_SCRIPT" != "undefined"]]; then
+if [[ "$TEST_SCRIPT" != "undefined" ]]; then
     # Check that jest exists and that it is being used in the script, either directly or through CRA
     if [[ -d "./node_modules/jest" && "$SCRIPT" == *react-scripts* || "$SCRIPT" == *jest* ]]; then
         TEST_REPORTER="jest-sonar-reporter"
@@ -138,7 +138,7 @@ if [[ "$TEST_SCRIPT" != "undefined"]]; then
 fi
 
 # Run 'lint'
-if [[ "$LINT_SCRIPT" != "undefined"]]; then
+if [[ "$LINT_SCRIPT" != "undefined" ]]; then
     SCRIPT=$(node -pe "require('./package.json').scripts.lint");
     ESLINT_DEP=$(node -pe "require('./package.json').dependencies.eslint");
     ESLINT_DEV_DEP=$(node -pe "require('./package.json').devDependencies.eslint");

--- a/scripts/test/unit-node.sh
+++ b/scripts/test/unit-node.sh
@@ -85,15 +85,15 @@ if [[ -d "./node_modules/jest" && "$SCRIPT" == *react-scripts* || "$SCRIPT" == *
     SONAR_FLAGS="$SONAR_FLAGS -Dsonar.test.inclusions=**/*.test.tsx,**/*.test.ts,**/*.test.jsx,**/*.test.js,**/*.spec.tsx,**/*.spec.ts,**/*.spec.js,**/*.spec.tsx"
     if [[ "$USE_NPM" == true ]]; then
         echo "Installing $TEST_REPORTER"
-        COMMAND_ARGS="-- --testResultsProcessor $TEST_REPORTER"
+        COMMAND_ARGS="-- --testResultsProcessor $TEST_REPORTER --coverage"
         npm i -D $TEST_REPORTER
     elif [[ "$USE_YARN" == true ]]; then
         echo "Installing $TEST_REPORTER"
-        COMMAND_ARGS="--testResultsProcessor $TEST_REPORTER"
+        COMMAND_ARGS="--testResultsProcessor $TEST_REPORTER --coverage"
         yarn add -D $TEST_REPORTER
     elif [[ "$USE_PNPM" == true ]]; then
         echo "Installing $TEST_REPORTER"
-        COMMAND_ARGS="-- --testResultsProcessor $TEST_REPORTER"
+        COMMAND_ARGS="-- --testResultsProcessor $TEST_REPORTER --coverage"
         pnpm i -D $TEST_REPORTER
     fi
 fi
@@ -107,19 +107,19 @@ if [[ -d "./node_modules/vitest" && "$SCRIPT" == *vitest* ]]; then
     # Support Typscript and other common naming standards
     SONAR_FLAGS="$SONAR_FLAGS -Dsonar.test.inclusions=**/*.test.tsx,**/*.test.ts,**/*.test.jsx,**/*.test.js,**/*.spec.tsx,**/*.spec.ts,**/*.spec.js,**/*.spec.tsx"
     if [[ "$USE_NPM" == true ]]; then
-        COMMAND_ARGS="-- --reporter $TEST_REPORTER --outputFile test-report.xml"
+        COMMAND_ARGS="-- --reporter $TEST_REPORTER --outputFile test-report.xml --coverage"
         if [[ ! -d "./node_modules/vitest-sonar-reporter" ]]; then
             echo "Installing $TEST_REPORTER"
             npm i -D $TEST_REPORTER
         fi
     elif [[ "$USE_YARN" == true ]]; then
-        COMMAND_ARGS="--reporter $TEST_REPORTER --outputFile test-report.xml"
+        COMMAND_ARGS="--reporter $TEST_REPORTER --outputFile test-report.xml --coverage"
         if [[ ! -d "./node_modules/vitest-sonar-reporter" ]]; then
             echo "Installing $TEST_REPORTER"
             yarn add -D $TEST_REPORTER
         fi
     elif [[ "$USE_PNPM" == true ]]; then
-        COMMAND_ARGS="-- --reporter $TEST_REPORTER --outputFile test-report.xml"
+        COMMAND_ARGS="-- --reporter $TEST_REPORTER --outputFile test-report.xml --coverage"
         if [[ ! -d "./node_modules/vitest-sonar-reporter" ]]; then
             echo "Installing $TEST_REPORTER"
             pnpm i -D $TEST_REPORTER

--- a/scripts/test/unit-node.sh
+++ b/scripts/test/unit-node.sh
@@ -78,12 +78,13 @@ if [[ "$TEST_SCRIPT" != "undefined" ]]; then
     SONAR_FLAGS="$SONAR_FLAGS -Dsonar.testExecutionReportPaths=test-report.xml"
     SONAR_FLAGS="$SONAR_FLAGS -Dsonar.tests=src"
     SONAR_FLAGS="$SONAR_FLAGS -Dsonar.test.inclusions=**/*.test.tsx,**/*.test.ts,**/*.test.jsx,**/*.test.js,**/*.spec.tsx,**/*.spec.ts,**/*.spec.js,**/*.spec.tsx"
-    COVERAGE_REPORTER="lcov"
     UNIT_TEST_REPORT_NAME="test-report.xml"
+    COMMAND_ARGS=""
     
     # Check that jest exists and that it is being used in the script, either directly or through CRA
     if [[ -d "./node_modules/jest" && "$TEST_SCRIPT" == *react-scripts* || "$TEST_SCRIPT" == *jest* ]]; then
         TEST_REPORTER="jest-sonar-reporter"
+        COMMAND_ARGS="-- --coverage --testResultsProcessor $TEST_REPORTER"
         if [[ ! -d "./node_modules/jest-sonar-reporter" ]]; then
             if [[ "$USE_NPM" == true ]]; then
                 echo "Installing $TEST_REPORTER"
@@ -101,6 +102,8 @@ if [[ "$TEST_SCRIPT" != "undefined" ]]; then
     # Check that vitest exists and that it is being used in the script
     if [[ -d "./node_modules/vitest" && "$TEST_SCRIPT" == *vitest* ]]; then
         TEST_REPORTER="vitest-sonar-reporter"
+        COVERAGE_PROVIDER="c8"
+        COMMAND_ARGS="-- --coverage.enabled --reporter=$TEST_REPORTER --outputFile=$UNIT_TEST_REPORT_NAME --coverage.reporter=$COVERAGE_REPORTER --coverage.provider=$COVERAGE_PROVIDER"
         if [[ ! -d "./node_modules/$TEST_REPORTER" ]]; then
             if [[ "$USE_NPM" == true ]]; then
                 echo "Installing $TEST_REPORTER"
@@ -114,22 +117,21 @@ if [[ "$TEST_SCRIPT" != "undefined" ]]; then
             fi
         fi
 
-        COVERAGE_REPORTER_DEP="@vitest/coverage-c8"
-        if [[ ! -d "./node_modules/$COVERAGE_REPORTER_DEP" ]]; then
+        COVERAGE_PROVIDER_DEP="@vitest/coverage-c8"
+        if [[ ! -d "./node_modules/$COVERAGE_PROVIDER_DEP" ]]; then
             if [[ "$USE_NPM" == true ]]; then
-                echo "Installing $COVERAGE_REPORTER_DEP"
-                npm i -D $COVERAGE_REPORTER_DEP
+                echo "Installing $COVERAGE_PROVIDER_DEP"
+                npm i -D $COVERAGE_PROVIDER_DEP
             elif [[ "$USE_YARN" == true ]]; then
-                echo "Installing $COVERAGE_REPORTER_DEP"
-                yarn add -D $COVERAGE_REPORTER_DEP
+                echo "Installing $COVERAGE_PROVIDER_DEP"
+                yarn add -D $COVERAGE_PROVIDER_DEP
             elif [[ "$USE_PNPM" == true ]]; then
-                echo "Installing $COVERAGE_REPORTER_DEP"
-                pnpm i -D $COVERAGE_REPORTER_DEP
+                echo "Installing $COVERAGE_PROVIDER_DEP"
+                pnpm i -D $COVERAGE_PROVIDER_DEP
             fi
         fi
     fi
 
-    COMMAND_ARGS="-- --reporter $TEST_REPORTER --outputFile $UNIT_TEST_REPORT_NAME --coverage --coverage.reporter $COVERAGE_REPORTER"
     npm test $COMMAND_ARGS
 
 fi

--- a/scripts/test/unit-node.sh
+++ b/scripts/test/unit-node.sh
@@ -103,8 +103,9 @@ if [[ "$TEST_SCRIPT" != "undefined" ]]; then
     if [[ -d "./node_modules/vitest" && "$TEST_SCRIPT" == *vitest* ]]; then
         COVERAGE_PROVIDER="c8"
         COVERAGE_REPORTER="lcov"
+        COVERAGE_INCLUDE="src"
         TEST_REPORTER="vitest-sonar-reporter"
-        COMMAND_ARGS="-- --coverage.enabled --reporter=$TEST_REPORTER --outputFile=$UNIT_TEST_REPORT_NAME --coverage.reporter=$COVERAGE_REPORTER --coverage.provider=$COVERAGE_PROVIDER"
+        COMMAND_ARGS="-- --coverage.enabled --reporter=$TEST_REPORTER --outputFile=$UNIT_TEST_REPORT_NAME --coverage.reporter=$COVERAGE_REPORTER --coverage.provider=$COVERAGE_PROVIDER --coverage.include=$COVERAGE_INCLUDE"
 
         if [[ ! -d "./node_modules/$TEST_REPORTER" ]]; then
             if [[ "$USE_NPM" == true ]]; then

--- a/scripts/test/unit-node.sh
+++ b/scripts/test/unit-node.sh
@@ -105,23 +105,19 @@ if [[ "$TEST_SCRIPT" != "undefined" ]]; then
     if [[ -d "./node_modules/vitest" && "$TEST_SCRIPT" == *vitest* ]]; then
         COVERAGE_PROVIDER="c8"
         COVERAGE_REPORTER="lcov"
-        echo "USER_INCLUSIONS=$USER_INCLUSIONS"
-        COVERAGE_INCLUDE=
-        if [ "$USER_INCLUSIONS" != "undefined" ]; then
-            COVERAGE_INCLUDE=$USER_INCLUSIONS
+        COMMAND_ARGS="-- --coverage.enabled --reporter=$TEST_REPORTER --outputFile=$UNIT_TEST_REPORT_NAME --coverage.reporter=$COVERAGE_REPORTER --coverage.provider=$COVERAGE_PROVIDER --coverage.all=true"
+        echo "USER_INCLUSIONS=[$USER_INCLUSIONS]"
+        if [[ "$USER_INCLUSIONS" != "undefined" && "$USER_INCLUSIONS" != "" ]]; then
+            COMMAND_ARGS="$COMMAND_ARGS --coverage.include=$USER_INCLUSIONS"
         else
-            COVERAGE_INCLUDE="**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"
+            COMMAND_ARGS="$COMMAND_ARGS --coverage.include=src"
         fi
-        echo "USER_EXCLUSIONS=$USER_EXCLUSIONS"
-        COVERAGE_EXCLUDE=
-        if [ "$USER_EXCLUSIONS" != "undefined" ]; then
-            COVERAGE_EXCLUDE=$USER_EXCLUSIONS
-        else
-            COVERAGE_EXCLUDE="**/node_modules/**,**/dist/**,**/cypress/**,**/.{idea,git,cache,output,temp}/**,**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*"
+        echo "USER_EXCLUSIONS=[$USER_EXCLUSIONS]"
+        if [[ "$USER_EXCLUSIONS" != "undefined" && "$USER_EXCLUSIONS" != "" ]]; then
+            COMMAND_ARGS="$COMMAND_ARGS --coverage.exclude=$USER_EXCLUSIONS"
         fi
-        TEST_REPORTER="vitest-sonar-reporter"
-        COMMAND_ARGS="-- --coverage.enabled --reporter=$TEST_REPORTER --outputFile=$UNIT_TEST_REPORT_NAME --coverage.reporter=$COVERAGE_REPORTER --coverage.provider=$COVERAGE_PROVIDER --coverage.include=$COVERAGE_INCLUDE --coverage.exclude=$COVERAGE_EXCLUDE --coverage.all=true"
 
+        TEST_REPORTER="vitest-sonar-reporter"      
         if [[ ! -d "./node_modules/$TEST_REPORTER" ]]; then
             if [[ "$USE_NPM" == true ]]; then
                 echo "Installing $TEST_REPORTER"

--- a/scripts/test/unit-node.sh
+++ b/scripts/test/unit-node.sh
@@ -103,7 +103,7 @@ if [[ "$TEST_SCRIPT" != "undefined" ]]; then
 
     # Check that vitest exists and that it is being used in the script
     if [[ -d "./node_modules/vitest" && "$TEST_SCRIPT" == *vitest* ]]; then
-        TEST_REPORTER="vitest-sonar-reporter"
+        TEST_REPORTER="vitest-sonar-reporter"      
         COVERAGE_PROVIDER="c8"
         COVERAGE_REPORTER="lcov"
         COMMAND_ARGS="-- --coverage.enabled --reporter=$TEST_REPORTER --outputFile=$UNIT_TEST_REPORT_NAME --coverage.reporter=$COVERAGE_REPORTER --coverage.provider=$COVERAGE_PROVIDER --coverage.all=true"

--- a/scripts/test/unit-node.sh
+++ b/scripts/test/unit-node.sh
@@ -105,6 +105,8 @@ if [[ "$TEST_SCRIPT" != "undefined" ]]; then
         COVERAGE_REPORTER="lcov"
         TEST_REPORTER="vitest-sonar-reporter"
         COMMAND_ARGS="-- --coverage.enabled --reporter=$TEST_REPORTER --outputFile=$UNIT_TEST_REPORT_NAME --coverage.reporter=$COVERAGE_REPORTER --coverage.provider=$COVERAGE_PROVIDER"
+
+
         if [[ ! -d "./node_modules/$TEST_REPORTER" ]]; then
             if [[ "$USE_NPM" == true ]]; then
                 echo "Installing $TEST_REPORTER"
@@ -135,6 +137,12 @@ if [[ "$TEST_SCRIPT" != "undefined" ]]; then
     fi
 
     npm test $COMMAND_ARGS
+
+    COVERAGE_REPORT=coverage/lcov.info
+    SONAR_FLAGS="$SONAR_FLAGS -Dsonar.javascript.lcov.reportPaths=$COVERAGE_REPORT"
+    ls -al $COVERAGE_REPORT
+    cat $COVERAGE_REPORT
+    echo "SONAR_FLAGS=$SONAR_FLAGS"
 fi
 
 # Run 'lint'
@@ -143,9 +151,8 @@ if [[ "$LINT_SCRIPT" != "undefined" ]]; then
     ESLINT_DEV_DEP=$(node -pe "require('./package.json').devDependencies.eslint");
     if [[ "$ESLINT_DEP" != "undefined" ]] || [[ "$ESLINT_DEV_DEP" != "undefined" ]]; then
         LINT_REPORT=lint-report.json
-        COVERAGE_REPORT=coverage/lcov.info
         npm run lint -- -f json -o $LINT_REPORT
-        SONAR_FLAGS="$SONAR_FLAGS -Dsonar.eslint.reportPaths=$LINT_REPORT -Dsonar.javascript.lcov.reportPaths=$COVERAGE_REPORT"
+        SONAR_FLAGS="$SONAR_FLAGS -Dsonar.eslint.reportPaths=$LINT_REPORT"
         ls -al $LINT_REPORT
     fi
     echo "SONAR_FLAGS=$SONAR_FLAGS"

--- a/scripts/test/unit-node.sh
+++ b/scripts/test/unit-node.sh
@@ -108,19 +108,19 @@ if [[ -d "./node_modules/vitest" && "$SCRIPT" == *vitest* ]]; then
     SONAR_FLAGS="$SONAR_FLAGS -Dsonar.test.inclusions=**/*.test.tsx,**/*.test.ts,**/*.test.jsx,**/*.test.js,**/*.spec.tsx,**/*.spec.ts,**/*.spec.js,**/*.spec.tsx"
     if [[ "$USE_NPM" == true ]]; then
         COMMAND_ARGS="-- --reporter $TEST_REPORTER --outputFile test-report.xml"
-        if [[ -d "./node_modules/vitest-sonar-reporter" ]]; then
+        if [[ ! -d "./node_modules/vitest-sonar-reporter" ]]; then
             echo "Installing $TEST_REPORTER"
             npm i -D $TEST_REPORTER
         fi
     elif [[ "$USE_YARN" == true ]]; then
         COMMAND_ARGS="--reporter $TEST_REPORTER --outputFile test-report.xml"
-        if [[ -d "./node_modules/vitest-sonar-reporter" ]]; then
+        if [[ ! -d "./node_modules/vitest-sonar-reporter" ]]; then
             echo "Installing $TEST_REPORTER"
             yarn add -D $TEST_REPORTER
         fi
     elif [[ "$USE_PNPM" == true ]]; then
         COMMAND_ARGS="-- --reporter $TEST_REPORTER --outputFile test-report.xml"
-        if [[ -d "./node_modules/vitest-sonar-reporter" ]]; then
+        if [[ ! -d "./node_modules/vitest-sonar-reporter" ]]; then
             echo "Installing $TEST_REPORTER"
             pnpm i -D $TEST_REPORTER
         fi

--- a/scripts/test/unit-node.sh
+++ b/scripts/test/unit-node.sh
@@ -78,6 +78,7 @@ if [[ "$TEST_SCRIPT" != "undefined" ]]; then
     SONAR_FLAGS="$SONAR_FLAGS -Dsonar.testExecutionReportPaths=test-report.xml"
     SONAR_FLAGS="$SONAR_FLAGS -Dsonar.tests=src"
     SONAR_FLAGS="$SONAR_FLAGS -Dsonar.test.inclusions=**/*.test.tsx,**/*.test.ts,**/*.test.jsx,**/*.test.js,**/*.spec.tsx,**/*.spec.ts,**/*.spec.js,**/*.spec.tsx"
+    COVERAGE_REPORTER="lcov"
     UNIT_TEST_REPORT_NAME="test-report.xml"
     
     # Check that jest exists and that it is being used in the script, either directly or through CRA
@@ -100,7 +101,7 @@ if [[ "$TEST_SCRIPT" != "undefined" ]]; then
     # Check that vitest exists and that it is being used in the script
     if [[ -d "./node_modules/vitest" && "$TEST_SCRIPT" == *vitest* ]]; then
         TEST_REPORTER="vitest-sonar-reporter"
-        if [[ ! -d "./node_modules/vitest-sonar-reporter" ]]; then
+        if [[ ! -d "./node_modules/$TEST_REPORTER" ]]; then
             if [[ "$USE_NPM" == true ]]; then
                 echo "Installing $TEST_REPORTER"
                 npm i -D $TEST_REPORTER
@@ -112,9 +113,23 @@ if [[ "$TEST_SCRIPT" != "undefined" ]]; then
                 pnpm i -D $TEST_REPORTER
             fi
         fi
+
+        COVERAGE_REPORTER_DEP="@vitest/coverage-c8"
+        if [[ ! -d "./node_modules/$COVERAGE_REPORTER_DEP" ]]; then
+            if [[ "$USE_NPM" == true ]]; then
+                echo "Installing $COVERAGE_REPORTER_DEP"
+                npm i -D $COVERAGE_REPORTER_DEP
+            elif [[ "$USE_YARN" == true ]]; then
+                echo "Installing $COVERAGE_REPORTER_DEP"
+                yarn add -D $COVERAGE_REPORTER_DEP
+            elif [[ "$USE_PNPM" == true ]]; then
+                echo "Installing $COVERAGE_REPORTER_DEP"
+                pnpm i -D $COVERAGE_REPORTER_DEP
+            fi
+        fi
     fi
 
-    COMMAND_ARGS="-- --reporter $TEST_REPORTER --outputFile $UNIT_TEST_REPORT_NAME --coverage"
+    COMMAND_ARGS="-- --reporter $TEST_REPORTER --outputFile $UNIT_TEST_REPORT_NAME --coverage --coverage.reporter $COVERAGE_REPORTER"
     npm test $COMMAND_ARGS
 
 fi


### PR DESCRIPTION
Closes #

Closes #32
Tag: 6.4.0-node.5

#### Changelog

**New**

- Pass flags to linting command if present in static for correct output format and file so users don't have to configure anything for SQ to work. 

**Changed**

- Fix installation of `vitest-sonar-reporter` if not present to format unit test output correctly for SQ

**Removed**

- Nada

#### Testing / Reviewing

- Make sure the unit and static testing work with vitest and eslint
