### PR TITLE
fix: pass in build script param

### DIFF
--- a/commands/build.js
+++ b/commands/build.js
@@ -234,7 +234,7 @@ module.exports = {
 
       await exec(`${shellDir}/build/compile-node.sh \
       "${taskParams["languageVersion"]}" \
-      "${taskParams["packageScript"]}"`);
+      "${taskParams["buildScript"]}"`);
     } catch (e) {
       log.err("  Error encountered. Code: " + e.code + ", Message:", e.message);
       process.exit(1);

--- a/commands/build.js
+++ b/commands/build.js
@@ -425,7 +425,6 @@ module.exports = {
         "${taskParams["gitCommitId"]}" \
         "${taskParams["repoIndexBranch"]}"`
       );
-      qq;
     } catch (e) {
       log.err("  Error encountered. Code: " + e.code + ", Message:", e.message);
       process.exit(1);

--- a/scripts/build/compile-node.sh
+++ b/scripts/build/compile-node.sh
@@ -13,7 +13,7 @@ if [ "$LANGUAGE_VERSION" != "undefined" ] && [ "$LANGUAGE_VERSION" != "" ]; then
     nvm use $LANGUAGE_VERSION
 fi
 
-if [ -z "$BUILD_SCRIPT" ]; then
+if [ "$BUILD_SCRIPT" != "undefined" ] && [ "$BUILD_SCRIPT" != "" ]; then
     echo "Build script not specified, defaulting to 'build'..."
     BUILD_SCRIPT=build
 else

--- a/scripts/build/compile-node.sh
+++ b/scripts/build/compile-node.sh
@@ -14,10 +14,10 @@ if [ "$LANGUAGE_VERSION" != "undefined" ] && [ "$LANGUAGE_VERSION" != "" ]; then
 fi
 
 if [ "$BUILD_SCRIPT" != "undefined" ] && [ "$BUILD_SCRIPT" != "" ]; then
+    echo "Setting build script to $BUILD_SCRIPT..."
+else
     echo "Build script not specified, defaulting to 'build'..."
     BUILD_SCRIPT=build
-else
-    echo "Setting build script to $BUILD_SCRIPT..."
 fi
 
 # Set JS heap space

--- a/scripts/build/initialize-dependencies-node.sh
+++ b/scripts/build/initialize-dependencies-node.sh
@@ -16,17 +16,9 @@ fi
 
 echo "Using build tool $BUILD_TOOL"
 
-if [ -z "$BUILD_SCRIPT" ]; then
-    echo "Build script not specified, defaulting to 'build'..."
-    BUILD_SCRIPT=build
-else
-    echo "Setting build script to $BUILD_SCRIPT..."
-fi
-
 if [ "$DEBUG" == "true" ]; then
     echo "DEBUG - Script input variables..."
     echo "LANGUAGE_VERSION=$LANGUAGE_VERSION"
-    echo "BUILD_SCRIPT=$BUILD_SCRIPT"
 fi
 
 # Install configured version of Node.js via nvm if present


### PR DESCRIPTION
Closes #

Closed #49 

#### Changelog

**Changed**

- Pass in `build-script` param to the node compilation script

**Removed**

- Some irrelevant build script related code in the dependencies setup script

#### Testing / Reviewing

`build-script` should now work as a parameter and used instead of the default `build` command. 
