### PR TITLE
remove setting of sonar.tests

### DIFF
--- a/scripts/test/unit-node.sh
+++ b/scripts/test/unit-node.sh
@@ -223,8 +223,11 @@ if [ "$SRC_FOLDER" == "." ]; then
     echo "SONAR_EXCLUSIONS=$SONAR_EXCLUSIONS"
 fi
 
-# Set sonar.tests to SRC_FOLDER
-SONAR_FLAGS="$SONAR_FLAGS -Dsonar.tests=$SRC_FOLDER"
+#####
+##### Removed - Cannot set "sonar.tests" to same location as "sonar.sources" as this causes duplicate index error in Sonarqube
+#####
+# # Set sonar.tests to SRC_FOLDER
+# SONAR_FLAGS="$SONAR_FLAGS -Dsonar.tests=$SRC_FOLDER"
 
 # Set Node.js bin path
 NODE_PATH=$(which node)


### PR DESCRIPTION
Remove setting of sonar.tests as it causes a duplicate index error in Sonarqube when it is set to the same value as sonar.sources.